### PR TITLE
Feature/common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 .metadata
 .settings/
 /bin/
+*.zip
+*.log

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2014 SeaClouds
+    Contact: SeaClouds
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>eu.seaclouds-project</groupId>
+    <artifactId>platform</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>eu.seaclouds-project</groupId>
+  <artifactId>common</artifactId>
+  <packaging>jar</packaging>
+  <description>SeaClouds common module</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>brooklyn-launcher</artifactId>
+      <version>${brooklyn.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>brooklyn-software-base</artifactId>
+      <version>${brooklyn.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>brooklyn-software-database</artifactId>
+      <version>${brooklyn.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>brooklyn-software-webapp</artifactId>
+      <version>${brooklyn.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>brooklyn-test-support</artifactId>
+      <version>${brooklyn.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>brooklyn-core</artifactId>
+      <version>${brooklyn.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.brooklyn</groupId>
+      <artifactId>brooklyn-launcher</artifactId>
+      <version>${brooklyn.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.jclouds.provider</groupId>
+          <artifactId>softlayer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds.labs</groupId>
+          <artifactId>docker</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds.labs</groupId>
+          <artifactId>vcloud-director</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds.labs</groupId>
+          <artifactId>dmtf</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/common/src/main/java/eu/seaclouds/common/apps/SeaCloudsApp.java
+++ b/common/src/main/java/eu/seaclouds/common/apps/SeaCloudsApp.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2014 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package eu.seaclouds.common.apps;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
+
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.Entity;
+import brooklyn.entity.basic.AbstractApplication;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.basic.Entities;
+import brooklyn.entity.basic.MethodEffector;
+import brooklyn.entity.basic.SoftwareProcess;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.location.Location;
+import brooklyn.management.internal.CollectionChangeListener;
+import brooklyn.management.internal.ManagementContextInternal;
+import brooklyn.policy.PolicySpec;
+import brooklyn.policy.basic.AbstractPolicy;
+import brooklyn.util.flags.SetFromFlag;
+import brooklyn.util.text.Strings;
+import eu.seaclouds.common.policies.DataCollectorInstallationPolicy;
+
+public class SeaCloudsApp extends AbstractApplication {
+   /**
+    * The default name to use for this app, if not explicitly overridden by the top-level app.
+    * Necessary to avoid the app being wrapped in another layer of "BasicApplication" on deployment.
+    * Previously, the catalog item gave an explicit name (rathe than this defaultDisplayName), which
+    * meant that if the user chose a different name then AMP would automatically wrap this app so
+    * that both names would be presented.
+    */
+   public static final ConfigKey<String> DEFAULT_DISPLAY_NAME = ConfigKeys.newStringConfigKey("defaultDisplayName");
+
+   /**
+    * childSpec.
+    */
+   @SuppressWarnings("serial")
+   public static final ConfigKey<EntitySpec<?>> CHILD_SPEC = ConfigKeys.newConfigKey(
+           new TypeToken<EntitySpec<?>>() {
+           },
+           "childSpec");
+
+   /**
+    * Config Key for Install Data CollectorOption.
+    */
+   @SetFromFlag("installDataCollector")
+   public static final ConfigKey<Boolean> INSTALL_DATA_COLLECTOR = ConfigKeys
+           .newBooleanConfigKey("seaclouds.installDataCollector",
+                   "Determines whether the Data Collector agent is installed",
+                   Boolean.TRUE);
+
+   private static final Logger LOG = LoggerFactory.getLogger(SeaCloudsApp.class);
+
+   @Override
+   public void init() {
+      super.init();
+      if (Strings.isNonBlank(getConfig(DEFAULT_DISPLAY_NAME))) {
+         setDefaultDisplayName(getConfig(DEFAULT_DISPLAY_NAME));
+      }
+   }
+
+   /**
+    * stopDataCollectorMonitoring method.
+    */
+   public final void stopDataCollectorMonitoring() {
+
+      for (final DataCollectorInstallationPolicy policy : this.getDescedentPolicies(DataCollectorInstallationPolicy.class)) {
+         policy.stopDataCollectorMonitoring();
+      }
+   }
+
+   /**
+    * startDataCollectorMonitoring method.
+    */
+   public final void startDataCollectorMonitoring(String ddaHostname, String ddaPort, String kbHostname, String kbPort) {
+
+      for (final DataCollectorInstallationPolicy policy : this.getDescedentPolicies(DataCollectorInstallationPolicy.class)) {
+         policy.startDataCollectorMonitoring(ddaHostname, ddaPort, kbHostname, kbPort);
+      }
+   }
+
+   /**
+    * Get Specific Policy Iterable.
+    *
+    * @param policyClass Compose Policy Class.
+    * @param <T>         Type which extends AbstractPolicy.
+    * @return Iterable<T> Specific Policy Class.
+    */
+   protected final <T extends AbstractPolicy> Iterable<T> getDescedentPolicies(Class<T> policyClass) {
+      final Set<T> descPolicy = Sets.newHashSet();
+      for (final SoftwareProcess descendents : Entities.descendants(this, SoftwareProcess.class)) {
+         descPolicy.addAll(ImmutableList
+                 .copyOf(Iterables.filter(descendents.getPolicies(), policyClass)));
+      }
+      return descPolicy;
+   }
+
+   @Override
+   public final void start(Collection<? extends Location> locations) {
+      addLocations(locations);
+      final Collection<? extends Location> locationsToUse = getLocations();
+      final EntitySpec<?> childSpec = getConfig(CHILD_SPEC);
+
+      this.getMutableEntityType()
+              .addEffector(new MethodEffector<Void>(SeaCloudsApp.class, "stopDataCollectorMonitoring"));
+      this.getMutableEntityType()
+              .addEffector(new MethodEffector(SeaCloudsApp.class, "startDataCollectorMonitoring"));
+
+      ((ManagementContextInternal) getManagementContext())
+              .addEntitySetListener(new CollectionChangeListener<Entity>() {
+
+                 @Override
+                 public void onItemAdded(Entity entity) {
+                    if (SeaCloudsApp.this.checkEntity(entity)) {
+                       final PolicySpec<DataCollectorInstallationPolicy> spec = PolicySpec.create(DataCollectorInstallationPolicy.class);
+                       entity.addPolicy(spec);
+                    }
+                 }
+
+                 @Override
+                 public void onItemRemoved(Entity entity) {
+                    // no action required
+                 }
+              });
+
+      final Entity child = addChild(childSpec);
+      Entities.manage(child);
+
+      super.start(locationsToUse);
+   }
+
+   private boolean checkEntity(Entity entity) {
+      return entity instanceof SoftwareProcess
+              && Entities.isAncestor(entity, this)
+              && Iterables.isEmpty(Iterables.filter(entity.getPolicies(), DataCollectorInstallationPolicy.class));
+   }
+
+}

--- a/common/src/main/java/eu/seaclouds/common/policies/DataCollectorInstallationPolicy.java
+++ b/common/src/main/java/eu/seaclouds/common/policies/DataCollectorInstallationPolicy.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2014 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package eu.seaclouds.common.policies;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.AbstractEntity;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.basic.EntityLocal;
+import brooklyn.event.SensorEvent;
+import brooklyn.event.SensorEventListener;
+import brooklyn.location.Location;
+import brooklyn.location.OsDetails;
+import brooklyn.location.basic.Locations;
+import brooklyn.location.basic.SshMachineLocation;
+import brooklyn.policy.basic.AbstractPolicy;
+import brooklyn.util.collections.MutableMap;
+import brooklyn.util.config.ConfigBag;
+import brooklyn.util.flags.SetFromFlag;
+import brooklyn.util.internal.ssh.SshTool;
+import brooklyn.util.ssh.BashCommands;
+import eu.seaclouds.common.apps.SeaCloudsApp;
+
+/**
+ * MODAClouds data collector installation policy Class enables User's VM monitoring.
+ * This class gets called on creation of new node, which will in turn installs
+ * MODAClouds data collector on targeted VM.
+ */
+public class DataCollectorInstallationPolicy extends AbstractPolicy {
+
+   private static final Logger LOG = LoggerFactory.getLogger(DataCollectorInstallationPolicy.class);
+   public static final String INSTALL_DIR = "~/datacollectors";
+   public static final String PID_FILENAME = "pid.txt";
+
+   @SetFromFlag("modacloudsDdaIp")
+   public static final ConfigKey<String> MODACLOUDS_DDA_IP = ConfigKeys.newStringConfigKey("modaclouds.dda.ip", "", "127.0.0.1");
+
+   @SetFromFlag("modacloudsDdaPort")
+   public static final ConfigKey<String> MODACLOUDS_DDA_PORT = ConfigKeys.newStringConfigKey("modaclouds.dda.port", "", "8175");
+
+   @SetFromFlag("modacloudsKbIp")
+   public static final ConfigKey<String> MODACLOUDS_KB_IP = ConfigKeys.newStringConfigKey("modaclouds.kb.ip", "", "127.0.0.1");
+
+   @SetFromFlag("modacloudsKbPort")
+   public static final ConfigKey<String> MODACLOUDS_KB_PORT = ConfigKeys.newStringConfigKey("modaclouds.kb.port", "", "3030");
+
+   private final AtomicBoolean dataCollectorInstalled = new AtomicBoolean(false);
+
+   /**
+    * Get dataCollectorInstalled flag.
+    *
+    * @return AtomicBoolean.
+    */
+   public final AtomicBoolean getDataCollectorInstalled() {
+      return this.dataCollectorInstalled;
+   }
+
+   /**
+    * Handle Policy Events.
+    *
+    * @param entity blueprint entity.
+    */
+   @Override public final void setEntity(final EntityLocal entity) {
+      super.setEntity(entity);
+      subscribe(entity, AbstractEntity.LOCATION_ADDED, new SensorEventListener<Location>() {
+         /**
+          * Location added event.
+          * @param sensorEvent SensorEvent.
+          */
+         @Override public void onEvent(SensorEvent<Location> sensorEvent) {
+            final Object sensorEventValue = sensorEvent.getValue();
+            if (sensorEventValue instanceof SshMachineLocation) {
+               final Boolean installDataCollector = entity.getConfig(SeaCloudsApp.INSTALL_DATA_COLLECTOR);
+               if (installDataCollector) {
+                  DataCollectorInstallationPolicy.this.installDataCollector((SshMachineLocation) sensorEventValue);
+                  getManagementContext().getConfig().getConfig(MODACLOUDS_DDA_IP);
+                  String ddaHostname = DataCollectorInstallationPolicy.this.getConfig(MODACLOUDS_DDA_IP);
+                  String ddaPort = DataCollectorInstallationPolicy.this.getConfig(MODACLOUDS_DDA_PORT);
+                  String kbHostname = DataCollectorInstallationPolicy.this.getConfig(MODACLOUDS_KB_IP);
+                  String kbPort = DataCollectorInstallationPolicy.this.getConfig(MODACLOUDS_KB_PORT);
+                  DataCollectorInstallationPolicy.this.startDataCollectorMonitoring(ddaHostname, ddaPort, kbHostname, kbPort);
+               }
+            }
+         }
+      });
+
+      subscribe(entity, AbstractEntity.LOCATION_REMOVED, new SensorEventListener<Location>() {
+         /**
+          * Location removed event.
+          *
+          * @param sensorEvent SensorEvent.
+          */
+         @Override public void onEvent(SensorEvent<Location> sensorEvent) {
+            final Object sensorEventValue = sensorEvent.getValue();
+            if (sensorEventValue instanceof SshMachineLocation) {
+               DataCollectorInstallationPolicy.this.uninstallDataCollector((SshMachineLocation) sensorEventValue);
+            }
+         }
+      });
+   }
+
+   /**
+    * Install Data collector Monitoring.
+    *
+    */
+   private void installDataCollector(SshMachineLocation location) {
+      if (!this.getDataCollectorInstalled().getAndSet(true)) {
+
+         // Persist the changes to dataCollectorInstalled.
+         requestPersist();
+         ImmutableList.Builder<String> commandsBuilder = ImmutableList.builder();
+
+         commandsBuilder.add("mkdir -p " + INSTALL_DIR)
+                 .add("cd " + INSTALL_DIR);
+         OsDetails os = location.getOsDetails();
+         if (!os.isMac()) {
+            commandsBuilder.add(BashCommands.sudo(BashCommands.installJava(7)))
+                    .add(BashCommands.INSTALL_WGET)
+                    .add(BashCommands.INSTALL_UNZIP);
+         }
+         commandsBuilder.add("wget -O data-collector-1.3-SNAPSHOT.jar \"https://github.com/imperial-modaclouds/modaclouds-data-collectors/releases/download/1.3-Snapshot/data-collector-1.3-SNAPSHOT.jar\"")
+                 .add("wget -O hyperic-sigar-1.6.4.zip \"http://sourceforge.net/projects/sigar/files/sigar/1.6/hyperic-sigar-1.6.4.zip/download?use_mirror=switch\"")
+                 .add("unzip hyperic-sigar-1.6.4.zip");
+         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+         ConfigBag flags = ConfigBag.newInstance()
+                 .configure(SshTool.PROP_OUT_STREAM, stdout)
+                 .configure(SshTool.PROP_ERR_STREAM, stderr);
+         int exitStatus = location.execScript(flags.getAllConfig(), "test PATH", ImmutableList.of("echo $PATH"));
+
+         exitStatus = location.execScript(flags.getAllConfig(), "Download and run the data collector", commandsBuilder.build());
+         checkReturnValue(exitStatus, "Install Data Collector");
+      }
+   }
+
+   /**
+    * Validate script execution.
+    *
+    * @param returnvalue checkReturnValue method variable.
+    * @param phase       returns the phase value.
+    */
+   private void checkReturnValue(int returnvalue, String phase) {
+      if (returnvalue != 0) {
+         LOG.error("Error installing Data collector during '{}', return code {}", phase, returnvalue);
+         throw new IllegalStateException(
+                 String.format("Data collector installation failed during phase %s, return value %s ", phase,
+                         returnvalue));
+      }
+   }
+
+   /**
+    * Un-register Data collector Monitoring.
+    *
+    * @param location blueprint machine location.
+    */
+   private void uninstallDataCollector(SshMachineLocation location) {
+      if (this.getDataCollectorInstalled().getAndSet(false)) {
+         final List<String> commands = Lists.newArrayList();
+         commands.add("rm -rf " + INSTALL_DIR);
+         final int retval = location.execScript("uninstall the data collector", commands);
+         this.checkReturnValue(retval, "uninstall data collector");
+      }
+   }
+
+   /**
+    * Stop Data collector Monitoring.
+    */
+   public final void stopDataCollectorMonitoring() {
+      requestPersist();
+      SshMachineLocation location = Locations.findUniqueSshMachineLocation(entity.getLocations()).get();
+      final List<String> commands = Lists.newArrayList();
+      commands.add("cd " + INSTALL_DIR);
+      commands.add(String.format("test -f %s && { kill -9 `cat %s`; rm %s;", PID_FILENAME, PID_FILENAME, PID_FILENAME));
+      final int retV = location.execScript("Stop data collector Process", commands);
+      this.checkReturnValue(retV, "stop data collector process");
+   }
+
+   /**
+    * Start Data collector Monitoring.
+    */
+   public final void startDataCollectorMonitoring(String ddaHostname, String ddaPort, String kbHostname, String kbPort) {
+      requestPersist();
+      final SshMachineLocation location = (SshMachineLocation) entity.getLocations().iterator().next();
+      final List<String> commands = Lists.newArrayList();
+      commands.add("cd " + INSTALL_DIR);
+      commands.add("nohup java -Djava.library.path=./hyperic-sigar-1.6.4/sigar-bin/lib/ -jar data-collector-1.3-SNAPSHOT.jar kb &");
+      commands.add(String.format("echo $! > %s", PID_FILENAME));
+      ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+      ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+      ConfigBag flags = ConfigBag.newInstance()
+              .configure(SshTool.PROP_NO_EXTRA_OUTPUT, true)
+              .configure(SshTool.PROP_OUT_STREAM, stdout)
+              .configure(SshTool.PROP_ERR_STREAM, stderr);
+      Map<String, String> env = MutableMap.of(
+              "MODACLOUDS_MONITORING_DDA_ENDPOINT_IP", ddaHostname,
+              "MODACLOUDS_MONITORING_DDA_ENDPOINT_PORT", ddaPort,
+              "MODACLOUDS_KNOWLEDGEBASE_ENDPOINT_IP", kbHostname,
+              "MODACLOUDS_KNOWLEDGEBASE_ENDPOINT_PORT", kbPort,
+              "MODACLOUDS_KNOWLEDGEBASE_DATASET_PATH", "/modaclouds/kb",
+              "MODACLOUDS_KNOWLEDGEBASE_SYNC_PERIOD", "10");
+      int ret = location.execScript(flags.getAllConfig(), "start data collector process", commands, env);
+      this.checkReturnValue(ret, "start data collector process");
+   }
+
+}

--- a/common/src/test/java/eu/seaclouds/common/compose/apps/AbstractSeaCloudsAppTest.java
+++ b/common/src/test/java/eu/seaclouds/common/compose/apps/AbstractSeaCloudsAppTest.java
@@ -1,0 +1,482 @@
+/**
+ * Copyright 2014 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package eu.seaclouds.common.compose.apps;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.io.File;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.HttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import brooklyn.catalog.CatalogLoadMode;
+import brooklyn.config.BrooklynProperties;
+import brooklyn.config.BrooklynServerConfig;
+import brooklyn.entity.Application;
+import brooklyn.entity.Entity;
+import brooklyn.entity.basic.Attributes;
+import brooklyn.entity.basic.Entities;
+import brooklyn.entity.basic.EntityLocal;
+import brooklyn.entity.basic.Lifecycle;
+import brooklyn.entity.basic.SoftwareProcess;
+import brooklyn.entity.basic.SoftwareProcess.RestartSoftwareParameters.RestartMachineMode;
+import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters.StopMode;
+import brooklyn.entity.rebind.RebindOptions;
+import brooklyn.entity.rebind.RebindTestUtils;
+import brooklyn.entity.rebind.persister.FileBasedObjectStore;
+import brooklyn.entity.trait.Startable;
+import brooklyn.event.AttributeSensor;
+import brooklyn.launcher.BrooklynLauncher;
+import brooklyn.launcher.SimpleYamlLauncherForTests;
+import brooklyn.launcher.camp.BrooklynCampPlatformLauncher;
+import brooklyn.location.Location;
+import brooklyn.management.ManagementContext;
+import brooklyn.management.Task;
+import brooklyn.management.internal.LocalManagementContext;
+import brooklyn.test.Asserts;
+import brooklyn.test.EntityTestUtils;
+import brooklyn.util.ResourceUtils;
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.http.HttpTool;
+import brooklyn.util.http.HttpToolResponse;
+import brooklyn.util.net.Urls;
+import brooklyn.util.os.Os;
+import brooklyn.util.yaml.Yamls;
+import io.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherAbstract;
+
+public abstract class AbstractSeaCloudsAppTest {
+
+   private static final Logger LOG = LoggerFactory.getLogger(AbstractSeaCloudsAppTest.class);
+
+   private File mementoDir;
+   private ClassLoader classLoader = AbstractSeaCloudsAppTest.class.getClassLoader();
+
+   private ManagementContext mgmt;
+   private SimpleYamlLauncherForTests launcher;
+   private BrooklynLauncher viewer;
+
+   private ExecutorService executor;
+
+   @BeforeMethod(alwaysRun = true)
+   public void setUp() throws Exception {
+      mementoDir = Os.newTempDir(getClass());
+      mgmt = createOrigManagementContext();
+      LOG.info("Test " + getClass() + " persisting to " + mementoDir);
+
+      launcher = new SimpleYamlLauncherForTests() {
+         @Override
+         protected BrooklynCampPlatformLauncherAbstract newPlatformLauncher() {
+            return new BrooklynCampPlatformLauncher() {
+               protected ManagementContext newManagementContext() {
+                  return AbstractSeaCloudsAppTest.this.mgmt;
+               }
+            };
+         }
+      };
+      viewer = BrooklynLauncher.newInstance()
+              .managementContext(mgmt)
+              .start();
+
+      executor = Executors.newCachedThreadPool();
+   }
+
+   @AfterMethod(alwaysRun = true)
+   public void tearDown() throws Exception {
+      try {
+         if (mgmt != null) {
+            for (Application app : mgmt.getApplications()) {
+               LOG.debug("destroying app " + app + " (managed? " + Entities.isManaged(app) + "; mgmt is " + mgmt + ")");
+               try {
+                  Entities.destroy(app);
+                  LOG.debug("destroyed app " + app + "; mgmt now " + mgmt);
+               } catch (Exception e) {
+                  LOG.error("problems destroying app " + app, e);
+               }
+            }
+         }
+         if (launcher != null) launcher.destroyAll();
+         if (viewer != null) viewer.terminate();
+         if (mgmt != null) Entities.destroyAll(mgmt);
+         if (mementoDir != null) FileBasedObjectStore.deleteCompletely(mementoDir);
+      } catch (Throwable t) {
+         LOG.error("Caught exception in tearDown method", t);
+      } finally {
+         if (executor != null) executor.shutdownNow();
+         executor = null;
+         mgmt = null;
+         launcher = null;
+      }
+   }
+
+   protected abstract String getLocationSpec();
+
+   protected Map<String, ?> getBrooklynProperties() {
+      return ImmutableMap.of();
+   }
+
+   protected Map<String, String> getCustomBlueprintConfig() {
+      return ImmutableMap.of();
+   }
+
+   protected Map<String, String> getCustomLocationConfig() {
+      return ImmutableMap.of();
+   }
+
+   protected void runTest(String url, Class<? extends SoftwareProcess> expectedType, AttributeSensor<String> endpoint, boolean expectsSubnetTier) throws Exception {
+      runTest(url, Predicates.instanceOf(expectedType), endpoint, expectsSubnetTier);
+   }
+
+   protected void runTest(String url, Predicate<? super Entity> typePredicate, AttributeSensor<String> endpoint, boolean expectsSubnetTier) throws Exception {
+      String catalogId = addToCatalog(url);
+
+      // Generate the yaml blueprint
+      Map<String, String> blueprintConfig = getCustomBlueprintConfig();
+      Map<String, String> locationConfig = getCustomLocationConfig();
+      StringBuilder yaml = new StringBuilder();
+
+      if (locationConfig.size() > 0) {
+         yaml.append("location: \n" +
+                 "  " + getLocationSpec() + ":\n");
+         for (Map.Entry<String, String> entry : locationConfig.entrySet()) {
+            yaml.append("    " + entry.getKey() + ": " + entry.getValue() + "\n");
+         }
+      } else {
+         yaml.append("location: " + getLocationSpec() + "\n");
+      }
+
+      yaml.append(
+              "services: \n" +
+                      "- type: " + catalogId + "\n");
+      if (blueprintConfig.size() > 0) {
+         yaml.append("  brooklyn.config:" + "\n");
+         for (Map.Entry<String, String> entry : blueprintConfig.entrySet()) {
+            yaml.append("    " + entry.getKey() + ": " + entry.getValue() + "\n");
+         }
+      }
+
+      // Deploy the blueprint
+      LOG.info("Deploying YAML:\n" + yaml);
+      Application app = launcher.launchAppYaml(new StringReader(yaml.toString()));
+
+      //  Confirm has expected entity/structure
+      Entity entity = Iterables.getOnlyElement(app.getChildren());
+      assertTrue(typePredicate.apply(entity), "entity=" + entity);
+
+      // Confirm healthy, and operations work
+      assertNoFires(app);
+      for (Entity softwareProcess : Entities.descendants(entity, Predicates.instanceOf(SoftwareProcess.class), true)) {
+         assertCanRestartProcess((SoftwareProcess) softwareProcess);
+      }
+
+      // Rebind, and find new entity instances
+      Application newApp = rebind();
+      Entity newEntity = Iterables.getOnlyElement(newApp.getChildren());
+
+      // Confirm still healthy, and operations still work
+      assertNoFires(newApp);
+      for (Entity softwareProcess : Entities.descendants(newEntity, Predicates.instanceOf(SoftwareProcess.class), true)) {
+         assertCanRestartProcess((SoftwareProcess) softwareProcess);
+      }
+   }
+
+   protected void runTestConcurrentDeploys(Map<String, Integer> urls) throws Exception {
+      runTestConcurrentDeploys(1, urls);
+   }
+
+   protected void runTestConcurrentDeploys(int numCycles, Map<String, Integer> urls) throws Exception {
+      Map<String, String> urlToCatalogId = Maps.newLinkedHashMap();
+      for (String url : urls.keySet()) {
+         String catalogId = addToCatalog(url);
+         urlToCatalogId.put(url, catalogId);
+      }
+
+      for (int cycle = 0; cycle < numCycles; cycle++) {
+         List<Future<Application>> futures = Lists.newArrayList();
+
+         for (Map.Entry<String, Integer> entry : urls.entrySet()) {
+            String catalogId = urlToCatalogId.get(entry.getKey());
+            int num = entry.getValue();
+
+            for (int i = 0; i < num; i++) {
+               // Generate the yaml blueprint
+               final StringBuilder yaml = new StringBuilder();
+               Map<String, String> blueprintConfig = getCustomBlueprintConfig();
+               Map<String, String> locationConfig = getCustomLocationConfig();
+
+               if (locationConfig.size() > 0) {
+                  yaml.append("location: \n" +
+                          "  " + getLocationSpec() + ":\n");
+                  for (Map.Entry<String, String> entry2 : locationConfig.entrySet()) {
+                     yaml.append("    " + entry2.getKey() + ": " + entry2.getValue() + "\n");
+                  }
+               } else {
+                  yaml.append("location: " + getLocationSpec() + "\n");
+               }
+
+               yaml.append(
+                       "services: \n" +
+                               "- type: " + catalogId + "\n");
+               if (blueprintConfig.size() > 0) {
+                  yaml.append("  brooklyn.config:" + "\n");
+                  for (Map.Entry<String, String> entry2 : blueprintConfig.entrySet()) {
+                     yaml.append("    " + entry2.getKey() + ": " + entry2.getValue() + "\n");
+                  }
+               }
+
+               // Deploy the blueprint
+               Future<Application> future = executor.submit(new Callable<Application>() {
+                  public Application call() {
+                     LOG.info("Deploying YAML:\n" + yaml);
+                     return launcher.launchAppYaml(new StringReader(yaml.toString()));
+                  }
+               });
+               futures.add(future);
+            }
+         }
+
+         //  Confirm all started without error
+         for (Future<Application> future : futures) {
+            Application app = future.get();
+            assertNoFires(app);
+         }
+      }
+
+      // Confirm can rebind, and that nothing goes/stays on fire after rebind
+      Application newApp = rebind();
+      Collection<Application> newApps = newApp.getManagementContext().getApplications();
+
+      // Check apps all healthy;
+      // TODO simplify code again (i.e. remove try-catch) when confident not having transient errors after rebind
+      try {
+         for (Application app : newApps) {
+            assertNoFires(app);
+         }
+      } catch (Throwable t) {
+         // Try again, in case it's a transient error
+         LOG.error("App(s) on fire after rebind; waiting 60 seconds and checking again", t);
+         Thread.sleep(60 * 1000);
+
+         try {
+            for (Application app : newApps) {
+               assertNoFires(app);
+            }
+            LOG.error("App(s) on fire after rebind; waiting 60 seconds and checking again", t);
+            throw new RuntimeException("App(s) were temporarily on fire, but recovered after 60 seconds", t);
+         } catch (Throwable t2) {
+            LOG.error("App(s) still on fire 60 seconds after rebind; throwing original exception", t2);
+            throw Exceptions.propagate(t);
+         }
+      }
+
+      // Confirm can stop all the apps
+      for (Application app : newApps) {
+         ((Startable) app).stop();
+      }
+   }
+
+   protected String addToCatalog(String yamlUri) {
+      String baseUri = viewer.getServerDetails().getWebServer().getRootUrl();
+      URI uri = URI.create(Urls.mergePaths(baseUri, "/v1/catalog/"));
+
+      String yaml = ResourceUtils.create(this).getResourceAsString(yamlUri);
+
+      // TODO Should really get symbolicName + version from the returned HTTP response
+      Iterable<Object> parsedYaml = Yamls.parseAll(yaml);
+      Object catalogSection = ((Map<?, ?>) Iterables.get(parsedYaml, 0)).get("brooklyn.catalog");
+      String catalogId = (String) ((Map<?, ?>) catalogSection).get("id");
+      String iconUrl = (String) ((Map<?, ?>) catalogSection).get("iconUrl");
+      Double version = (Double) ((Map<?, ?>) catalogSection).get("version");
+      String catalogRef = catalogId + ":" + Double.toString(version);
+
+      assertNotNull(catalogId);
+      assertTrue(ResourceUtils.create(this).doesUrlExist(iconUrl), "url=" + iconUrl);
+
+      HttpClient httpClient = HttpTool.httpClientBuilder()
+              .credentials(new UsernamePasswordCredentials("admin", "password"))
+              .uri(uri)
+              .build();
+
+      HttpToolResponse resp = HttpTool.httpPost(httpClient, uri, ImmutableMap.<String, String>of(), yaml.getBytes());
+      assertEquals(resp.getResponseCode(), 201);
+      LOG.info("Added to catalog: " + resp.getContentAsString());
+
+      // TODO Could/should return id:version, but that is currently breaking rebind.
+      // Need to investigate further.
+      return catalogId;
+   }
+
+   protected void assertNoFires(final Entity app) {
+      EntityTestUtils.assertAttributeEqualsEventually(app, Attributes.SERVICE_UP, true);
+      EntityTestUtils.assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+
+      Asserts.succeedsEventually(new Runnable() {
+         public void run() {
+            for (Entity entity : Entities.descendants(app)) {
+               assertNotEquals(entity.getAttribute(Attributes.SERVICE_STATE_ACTUAL), Lifecycle.ON_FIRE);
+               assertNotEquals(entity.getAttribute(Attributes.SERVICE_UP), false);
+
+               if (entity instanceof SoftwareProcess) {
+                  EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+                  EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_UP, Boolean.TRUE);
+               }
+            }
+         }
+      });
+   }
+
+   protected void assertCanRestartProcess(final SoftwareProcess entity) throws Exception {
+      Collection<Location> origLocs = entity.getLocations();
+      String origHostname = entity.getAttribute(SoftwareProcess.HOSTNAME);
+
+      // Stop the process
+      Task<?> stopTask = Entities.invokeEffector(
+              (EntityLocal) entity,
+              entity,
+              SoftwareProcess.STOP,
+              ImmutableMap.of(
+                      SoftwareProcess.StopSoftwareParameters.STOP_MACHINE_MODE.getName(), StopMode.NEVER,
+                      SoftwareProcess.StopSoftwareParameters.STOP_PROCESS_MODE.getName(), StopMode.ALWAYS));
+      stopTask.get();
+
+      EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+      EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+
+      // Re-start the process - expect the same set of locations and IPs
+      Task<?> restartTask = Entities.invokeEffector(
+              (EntityLocal) entity,
+              entity,
+              SoftwareProcess.RESTART,
+              ImmutableMap.of(SoftwareProcess.RestartSoftwareParameters.RESTART_MACHINE.getName(), RestartMachineMode.FALSE));
+      restartTask.get();
+
+      assertNoFires(entity);
+      assertEquals(entity.getLocations(), origLocs);
+      assertEquals(entity.getAttribute(SoftwareProcess.HOSTNAME), origHostname);
+   }
+
+   protected Reader loadYaml(String url, String location) {
+      String yaml =
+              "location: " + location + "\n" +
+                      new ResourceUtils(this).getResourceAsString(url);
+      return new StringReader(yaml);
+   }
+
+
+   //////////////////////////////////////////////////////////////////
+   // FOR REBIND                                                   //
+   // See brooklyn.entity.rebind.RebindTestFixture in core's tests //
+   //////////////////////////////////////////////////////////////////
+
+   /**
+    * rebinds, and sets newApp
+    */
+   protected Application rebind() throws Exception {
+      return rebind(RebindOptions.create());
+   }
+
+   protected Application rebind(RebindOptions options) throws Exception {
+      ManagementContext origMgmt = mgmt;
+      ManagementContext newMgmt = createNewManagementContext();
+      Collection<Application> origApps = origMgmt.getApplications();
+
+      options = RebindOptions.create(options);
+      if (options.classLoader == null) options.classLoader(classLoader);
+      if (options.mementoDir == null) options.mementoDir(mementoDir);
+      if (options.origManagementContext == null) options.origManagementContext(origMgmt);
+      if (options.newManagementContext == null) options.newManagementContext(newMgmt);
+
+      for (Application origApp : origApps) {
+         RebindTestUtils.waitForPersisted(origApp);
+      }
+
+      mgmt = options.newManagementContext;
+      Application newApp = RebindTestUtils.rebind(options);
+
+      if (launcher != null) {
+         launcher = new SimpleYamlLauncherForTests() {
+            @Override
+            protected BrooklynCampPlatformLauncherAbstract newPlatformLauncher() {
+               return new BrooklynCampPlatformLauncher() {
+                  protected ManagementContext newManagementContext() {
+                     return AbstractSeaCloudsAppTest.this.mgmt;
+                  }
+               };
+            }
+         };
+      }
+      if (viewer != null) {
+         viewer.terminate();
+         viewer = BrooklynLauncher.newInstance()
+                 .managementContext(mgmt)
+                 .start();
+      }
+
+      return newApp;
+   }
+
+   /**
+    * @return A started management context
+    */
+   protected LocalManagementContext createOrigManagementContext() {
+      BrooklynProperties properties = BrooklynProperties.Factory.newDefault();
+      properties.put(BrooklynServerConfig.CATALOG_LOAD_MODE, CatalogLoadMode.LOAD_BROOKLYN_CATALOG_URL);
+      properties.putAll(getBrooklynProperties());
+      return RebindTestUtils.managementContextBuilder(mementoDir, classLoader)
+              .properties(properties)
+              .persistPeriodMillis(1)
+              .forLive(true)
+              .emptyCatalog(true)
+              .buildStarted();
+   }
+
+   /**
+    * @return An unstarted management context
+    */
+   protected LocalManagementContext createNewManagementContext() {
+      BrooklynProperties properties = BrooklynProperties.Factory.newDefault();
+      properties.put(BrooklynServerConfig.CATALOG_LOAD_MODE, CatalogLoadMode.LOAD_BROOKLYN_CATALOG_URL_IF_NO_PERSISTED_STATE);
+      return RebindTestUtils.managementContextBuilder(mementoDir, classLoader)
+              .properties(properties)
+              .persistPeriodMillis(1)
+              .forLive(true)
+              .emptyCatalog(true)
+              .buildUnstarted();
+   }
+}

--- a/common/src/test/java/eu/seaclouds/common/compose/apps/SeaCloudsAppEc2LiveTest.java
+++ b/common/src/test/java/eu/seaclouds/common/compose/apps/SeaCloudsAppEc2LiveTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2014 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package eu.seaclouds.common.compose.apps;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import brooklyn.entity.database.mysql.MySqlNode;
+import brooklyn.entity.webapp.jboss.JBoss6Server;
+import brooklyn.entity.webapp.jboss.JBoss7Server;
+import brooklyn.entity.webapp.tomcat.TomcatServer;
+
+@Test(groups = { "Live" })
+public class SeaCloudsAppEc2LiveTest extends AbstractSeaCloudsAppTest {
+
+   public static final String LOCATION_SPEC = "aws-ec2-us-west";
+
+   @Override
+   protected String getLocationSpec() {
+      return LOCATION_SPEC;
+   }
+
+   @Test(groups = "Live")
+   public void testTomcat() throws Exception {
+      runTest("tomcat-catalog.yaml", TomcatServer.class, TomcatServer.ROOT_URL, false);
+   }
+
+   @Test(groups = "Live")
+   public void testJboss7() throws Exception {
+      runTest("jboss7-catalog.yaml", JBoss7Server.class, JBoss7Server.ROOT_URL, false);
+   }
+
+   @Test(groups = "Live")
+   public void testJboss6() throws Exception {
+      runTest("jboss6-catalog.yaml", JBoss6Server.class, JBoss6Server.ROOT_URL, false);
+   }
+
+   @Test(groups = "Live")
+   public void testMySql() throws Exception {
+      runTest("mysql-catalog.yaml", MySqlNode.class, MySqlNode.DATASTORE_URL, false);
+   }
+
+   @Test(groups = "Live")
+   public void testConcurrentDeploys() throws Exception {
+      final int NUM_CYCLES = 2;
+      final int NUM_PER_TYPE = 1;
+      runTestConcurrentDeploys(NUM_CYCLES, ImmutableMap.<String, Integer>builder()
+              .put("tomcat-catalog.yaml", NUM_PER_TYPE)
+              .put("jboss7-catalog.yaml", NUM_PER_TYPE)
+              .put("jboss6-catalog.yaml", NUM_PER_TYPE)
+              .put("mysql-catalog.yaml", NUM_PER_TYPE)
+              .build());
+   }
+}

--- a/common/src/test/java/eu/seaclouds/common/compose/apps/SeaCloudsAppIntegrationTest.java
+++ b/common/src/test/java/eu/seaclouds/common/compose/apps/SeaCloudsAppIntegrationTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2014 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package eu.seaclouds.common.compose.apps;
+
+import java.util.Map;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import brooklyn.entity.database.mysql.MySqlNode;
+import brooklyn.entity.webapp.jboss.JBoss6Server;
+import brooklyn.entity.webapp.jboss.JBoss7Server;
+import brooklyn.entity.webapp.tomcat.TomcatServer;
+
+@Test(groups = { "Integration" })
+public class SeaCloudsAppIntegrationTest extends AbstractSeaCloudsAppTest {
+
+   public static final String LOCATION_SPEC = "localhost";
+
+   private Map<String, String> customBlueprintConfig;
+   private Map<String, String> customLocationConfig;
+
+   @BeforeMethod(alwaysRun=true)
+   @Override
+   public void setUp() throws Exception {
+      customBlueprintConfig = null;
+      customLocationConfig = null;
+      super.setUp();
+   }
+
+   @Override
+   protected String getLocationSpec() {
+      return LOCATION_SPEC;
+   }
+
+   @Override
+   protected Map<String, String> getCustomBlueprintConfig() {
+      return (customBlueprintConfig == null) ? ImmutableMap.<String, String>of() : customBlueprintConfig;
+   }
+
+   @Override
+   protected Map<String, String> getCustomLocationConfig() {
+      return (customLocationConfig == null) ? ImmutableMap.<String, String>of() : customLocationConfig;
+   }
+
+   @Test(groups="Integration")
+   public void testTomcat() throws Exception {
+      runTest("tomcat-catalog.yaml", TomcatServer.class, TomcatServer.ROOT_URL, false);
+   }
+
+   @Test(groups="Integration")
+   public void testJboss7() throws Exception {
+      runTest("jboss7-catalog.yaml", JBoss7Server.class, JBoss7Server.ROOT_URL, false);
+   }
+
+   @Test(groups="Integration")
+   public void testJboss6() throws Exception {
+      runTest("jboss6-catalog.yaml", JBoss6Server.class, JBoss6Server.ROOT_URL, false);
+   }
+
+   @Test(groups="Integration")
+   public void testMySql() throws Exception {
+      runTest("mysql-catalog.yaml", MySqlNode.class, MySqlNode.DATASTORE_URL, false);
+   }
+}

--- a/common/src/test/java/eu/seaclouds/common/compose/policies/DataCollectorInstallationPolicyLiveTest.java
+++ b/common/src/test/java/eu/seaclouds/common/compose/policies/DataCollectorInstallationPolicyLiveTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2014 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package eu.seaclouds.common.compose.policies;
+
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import brooklyn.entity.Entity;
+import brooklyn.entity.webapp.tomcat.TomcatServer;
+import brooklyn.location.Location;
+import brooklyn.location.basic.SshMachineLocation;
+import brooklyn.test.Asserts;
+import eu.seaclouds.common.compose.apps.AbstractSeaCloudsAppTest;
+
+@Test(groups = { "Live" })
+public class DataCollectorInstallationPolicyLiveTest extends AbstractSeaCloudsAppTest {
+
+   public static final String LOCATION_SPEC = "softlayer-london-2";
+
+   @Override
+   protected String getLocationSpec() {
+      return LOCATION_SPEC;
+   }
+
+   @Test(groups = "Live")
+   public void testTomcat() throws Exception {
+      Predicate<Entity> testPredicate = new Predicate<Entity>() {
+         @Override
+         public boolean apply(Entity entity) {
+            Asserts.assertTrue(entity instanceof TomcatServer, "entity=" + entity);
+            Location location = Iterables.getOnlyElement((entity).getLocations());
+            Asserts.assertTrue(location instanceof SshMachineLocation, "location=" + location);
+            SshMachineLocation sshMachineLocation = (SshMachineLocation) location;
+            List<String> commands = ImmutableList.<String>builder()
+                    // FIXME: Check if data collector is installed
+                    .add("echo foo")
+                    .build();
+            int returnCode = sshMachineLocation.execScript("Checking for data collector", commands);
+            Assert.assertEquals(returnCode, 0, "Expected script to return 0, found " + returnCode);
+            return true;
+         }
+      };
+      runTest("tomcat-catalog-with-datacollector.yaml", testPredicate, TomcatServer.ROOT_URL, false);
+   }
+
+}

--- a/common/src/test/resources/jboss6-catalog.yaml
+++ b/common/src/test/resources/jboss6-catalog.yaml
@@ -1,0 +1,18 @@
+brooklyn.catalog:
+  id: eu.seaclouds-project.jboss6
+  version: 1.0
+  description: A JBoss 6 App-server
+  displayName: JBoss6
+  iconUrl: classpath:///jboss_logo.png
+  itemType: template
+
+  item:
+    services:
+    - type: eu.seaclouds.common.apps.SeaCloudsApp
+      defaultDisplayName: JBoss 6 app
+      brooklyn.config:
+        childSpec:
+          $brooklyn:entitySpec:
+            type: brooklyn.entity.webapp.jboss.JBoss6Server
+            id: childid
+            name: JBoss 6 Server

--- a/common/src/test/resources/jboss7-catalog.yaml
+++ b/common/src/test/resources/jboss7-catalog.yaml
@@ -1,0 +1,18 @@
+brooklyn.catalog:
+  id: eu.seaclouds-project.jboss7
+  version: 1.0
+  description: A JBoss 6 App-server
+  displayName: JBoss6
+  iconUrl: classpath:///jboss_logo.png
+  itemType: template
+
+  item:
+    services:
+    - type: eu.seaclouds.common.apps.SeaCloudsApp
+      defaultDisplayName: JBoss 6 app
+      brooklyn.config:
+        childSpec:
+          $brooklyn:entitySpec:
+            type: brooklyn.entity.webapp.jboss.JBoss7Server
+            id: childid
+            name: JBoss 7 Server

--- a/common/src/test/resources/mysql-catalog.yaml
+++ b/common/src/test/resources/mysql-catalog.yaml
@@ -1,0 +1,18 @@
+brooklyn.catalog:
+  id: eu.seaclouds-project.mysql
+  version: 1.0
+  description: A Tomcat app-server
+  displayName: Tomcat
+  iconUrl: classpath:///tomcat-logo.png
+  itemType: template
+
+  item:
+    services:
+    - type: eu.seaclouds.common.apps.SeaCloudsApp
+      defaultDisplayName: MySql app
+      brooklyn.config:
+        childSpec:
+          $brooklyn:entitySpec:
+            type: brooklyn.entity.database.mysql.MySqlNode
+            id: childid
+            name: MySql Server

--- a/common/src/test/resources/tomcat-catalog-with-datacollector.yaml
+++ b/common/src/test/resources/tomcat-catalog-with-datacollector.yaml
@@ -1,0 +1,23 @@
+brooklyn.catalog:
+  id: eu.seaclouds-project.tomcat
+  version: 1.0
+  description: A Tomcat app-server
+  displayName: Tomcat
+  iconUrl: classpath:///tomcat-logo.png
+  itemType: template
+
+  item:
+    services:
+    - type: eu.seaclouds.common.apps.SeaCloudsApp
+      defaultDisplayName: Tomcat
+      brooklyn.config:
+        childSpec:
+          $brooklyn:entitySpec:
+            type: brooklyn.entity.webapp.tomcat.TomcatServer
+            id: childid
+            name: Tomcat Server
+            brooklyn.policies:
+            - policyType: eu.seaclouds.common.policies.DataCollectorInstallationPolicy
+              brooklyn.config:
+                modacloudsDdaIp: 192.168.0.1
+                modacloudsKbIp: 192.168.0.2

--- a/common/src/test/resources/tomcat-catalog.yaml
+++ b/common/src/test/resources/tomcat-catalog.yaml
@@ -1,0 +1,18 @@
+brooklyn.catalog:
+  id: eu.seaclouds-project.tomcat
+  version: 1.0
+  description: A Tomcat app-server
+  displayName: Tomcat
+  iconUrl: classpath:///tomcat-logo.png
+  itemType: template
+
+  item:
+    services:
+    - type: eu.seaclouds.common.apps.SeaCloudsApp
+      defaultDisplayName: Tomcat
+      brooklyn.config:
+        childSpec:
+          $brooklyn:entitySpec:
+            type: brooklyn.entity.webapp.tomcat.TomcatServer
+            id: childid
+            name: Tomcat Server

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -69,11 +69,6 @@
       <artifactId>planner-core</artifactId>
       <version>0.1.0-SNAPSHOT</version>
     </dependency>
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.0.8.Final</version>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/planner/core/pom.xml
+++ b/planner/core/pom.xml
@@ -33,7 +33,6 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
-
     <dependency>
       <groupId>eu.seaclouds-project</groupId>
       <artifactId>matchmaker</artifactId>

--- a/planner/matchmaker/pom.xml
+++ b/planner/matchmaker/pom.xml
@@ -35,12 +35,6 @@ limitations under the License.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>eu.seaclouds-project</groupId>
     	<artifactId>planner-utils</artifactId>
     	<version>0.1.0-SNAPSHOT</version>

--- a/planner/optimizer/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
+++ b/planner/optimizer/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
@@ -18,6 +18,7 @@
 package eu.seaclouds.platform.planner.optimizer.nfp;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,7 +26,6 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import scala.actors.threadpool.Arrays;
 import eu.seaclouds.platform.planner.optimizer.CloudOffer;
 import eu.seaclouds.platform.planner.optimizer.Solution;
 import eu.seaclouds.platform.planner.optimizer.SuitableOptions;

--- a/planner/utils/src/main/java/seaclouds/utils/TOSCAYamlParser.java
+++ b/planner/utils/src/main/java/seaclouds/utils/TOSCAYamlParser.java
@@ -16,10 +16,6 @@
  */
 package seaclouds.utils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
-
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -27,6 +23,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
 
 public class TOSCAYamlParser {
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,8 @@
   <artifactId>platform</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <modules>
-    <module>monitor</module>
+    <module>common</module>
+    <!--module>monitor</module-->
     <module>deployer</module>
     <module>planner</module>
     <module>dashboard</module>
@@ -32,6 +33,7 @@
   <name>SeaClouds Platform</name>
   <url>http://www.seaclouds-project.eu</url>
   <properties>
+    <excludedTestGroups>Integration,Live</excludedTestGroups>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>18.0</guava.version>
     <javatuples.version>1.2</javatuples.version>
@@ -39,6 +41,7 @@
     <brooklyn.version>0.7.0-SNAPSHOT</brooklyn.version>
     <jetty.version>9.2.4.v20141103</jetty.version>
     <junit.version>4.11</junit.version>
+    <slf4j.version>1.6.6</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
   </properties>
 
   <repositories>
@@ -70,13 +73,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.brooklyn</groupId>
-      <artifactId>brooklyn-rest-client</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.javatuples</groupId>
@@ -86,6 +89,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -105,27 +109,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>**/*IntegrationTest.java</exclude>
-          </excludes>
+          <enableAssertions>true</enableAssertions>
+          <groups>${includedTestGroups}</groups>
+          <excludedGroups>${excludedTestGroups}</excludedGroups>
+          <testFailureIgnore>false</testFailureIgnore>
         </configuration>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <phase>integration-test</phase>
-            <configuration>
-              <excludes>
-                <exclude>none</exclude>
-              </excludes>
-              <includes>
-                <include>**/*IntegrationTest.java</include>
-              </includes>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -198,6 +186,7 @@
           </configuration>
       </plugin>
     </plugins>
+
   </build>
   <dependencyManagement>
     <dependencies>
@@ -223,4 +212,50 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <id>Live</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <!-- note that the groups/excluded groups don't work due to some problem
+                       in surefire or testng. instead, we have to exclude via file path
+                       <groups>live,integration</groups>
+                       <excludedGroups>unit,performance</excludedGroups> -->
+                  <excludes>
+                    <exclude>none</exclude>
+                  </excludes>
+                  <includes>
+                    <include>**/*IntegrationTest.java</include>
+                    <include>**/*LiveTest.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <!--
+                        If you're behind a proxy, set this here
+                        http://java.sun.com/javase/6/docs/technotes/guides/net/proxies.html
+
+<https.proxyHost>proxy</https.proxyHost>
+<https.proxyPort>port</https.proxyPort>
+<https.noProxyHosts>localhost|10.150.4.49</https.noProxyHosts>
+                    -->
+                    <file.encoding>${project.build.sourceEncoding}</file.encoding>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
- general clean up to the maven structure: commented monitor module, among other fixes, as not used
- add `common` module where the seaclouds app and the policies to install data collectors are defined
- I will move `brooklyn-modaclouds` entities to `common` there as soon as this gets merged

@MicheleGuerriero could you please take a look, particularly to the mechanism that installs the data collector for sigar?