### PR TITLE
Updates in usage/installer to support MODAClouds TOWER4 Clouds

### DIFF
--- a/usage/installer/src/main/java/eu/seaclouds/modaclouds/dda/MODACloudsDeterministicDataAnalizerSshDriver.java
+++ b/usage/installer/src/main/java/eu/seaclouds/modaclouds/dda/MODACloudsDeterministicDataAnalizerSshDriver.java
@@ -48,7 +48,7 @@ public class MODACloudsDeterministicDataAnalizerSshDriver extends JavaSoftwarePr
    @Override
    public void preInstall() {
       resolver = Entities.newDownloader(this);
-      setExpandedInstallDir(Os.mergePaths(getInstallDir(), resolver.getUnpackedDirectoryName(format("rsp-services-csparql-%s-modaclouds", getVersion()))));
+      setExpandedInstallDir(Os.mergePaths(getInstallDir(), resolver.getUnpackedDirectoryName(format("data-analyzer-%s", getVersion()))));
    }
 
    @Override
@@ -87,7 +87,7 @@ public class MODACloudsDeterministicDataAnalizerSshDriver extends JavaSoftwarePr
       newScript(MutableMap.of(USE_PID_FILE, getPidFile()), LAUNCHING)
               .failOnNonZeroResultCode()
               .body.append(
-               format("nohup java -jar rsp-services-csparql.jar > %s 2>&1 &", getLogFileLocation()))
+               format("nohup java -Xmx1200M -jar tower4clouds-data-analyzer.jar > %s 2>&1 &", getLogFileLocation()))
               .execute();
 
       String mainUri = String.format("http://%s:%d", entity.getAttribute(Attributes.HOSTNAME), entity.getAttribute(MODACloudsDeterministicDataAnalyzer.MODACLOUDS_DDA_PORT));

--- a/usage/installer/src/main/java/eu/seaclouds/modaclouds/dda/MODACloudsDeterministicDataAnalyzer.java
+++ b/usage/installer/src/main/java/eu/seaclouds/modaclouds/dda/MODACloudsDeterministicDataAnalyzer.java
@@ -40,16 +40,17 @@ public interface MODACloudsDeterministicDataAnalyzer extends SoftwareProcess, Ha
 
    @SetFromFlag("version")
    ConfigKey<String> SUGGESTED_VERSION =
-           ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.4.6.2");
+           ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.2");
 
    @SetFromFlag("downloadUrl")
    BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(
            SoftwareProcess.DOWNLOAD_URL, "https://github" +
-           ".com/deib-polimi/rsp-services-csparql/releases/download/${version}-modaclouds/rsp-services-csparql-${version}-modaclouds-distribution.tar.gz");
-
+           ".com/deib-polimi/tower4clouds/releases/download/v${version}/data-analyzer-${version}.tar.gz");
+   
    @SetFromFlag("modacloudsDeterministicDataAnalyzerPort")
    PortAttributeSensorAndConfigKey MODACLOUDS_DDA_PORT = new PortAttributeSensorAndConfigKey("modaclouds.dda.port",
            "MODAClouds Deterministic Data Analyzer port", "8175+");
+	
 
    AttributeSensor<URI> DDA_CONSOLE_URI = Attributes.MAIN_URI;
 }

--- a/usage/installer/src/main/java/eu/seaclouds/modaclouds/hdb/MODACloudsHistoryDB.java
+++ b/usage/installer/src/main/java/eu/seaclouds/modaclouds/hdb/MODACloudsHistoryDB.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package eu.seaclouds.modaclouds.kb;
+package eu.seaclouds.modaclouds.hdb;
 
 import java.net.URI;
 
@@ -33,29 +33,36 @@ import brooklyn.event.basic.BasicAttributeSensorAndConfigKey.StringAttributeSens
 import brooklyn.event.basic.PortAttributeSensorAndConfigKey;
 import brooklyn.util.flags.SetFromFlag;
 
-@Catalog(name = "MODAClouds Knowledge Base", description = "MODAClouds Knowledge Base", iconUrl = "classpath:///modaclouds.png")
-@ImplementedBy(MODACloudsKnowledgeBaseImpl.class)
-public interface MODACloudsKnowledgeBase extends SoftwareProcess, HasShortName {
+@Catalog(name = "MODAClouds History DB", description = "MODAClouds History DB", iconUrl = "classpath:///modaclouds.png")
+@ImplementedBy(MODACloudsHistoryDBImpl.class)
+public interface MODACloudsHistoryDB extends SoftwareProcess, HasShortName {
 
    @SetFromFlag("version")
    ConfigKey<String> SUGGESTED_VERSION =
-           ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.1.1");
+           ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.2");
 
    @SetFromFlag("downloadUrl")
    BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(
-           SoftwareProcess.DOWNLOAD_URL, "http://archive.apache.org/dist/jena/binaries/jena-fuseki-${version}-distribution.tar.gz");
+           SoftwareProcess.DOWNLOAD_URL, "https://github.com/deib-polimi/tower4clouds/releases/download/v${version}/rdf-history-db-main-${version}.tar.gz");
 
-   @SetFromFlag("modacloudsKnowledgeBasePort")
-   PortAttributeSensorAndConfigKey MODACLOUDS_KB_PORT = new PortAttributeSensorAndConfigKey("modaclouds.kb.port",
-           "MODAClouds Knowledge Base port", "3030+");
+   @SetFromFlag("modacloudsHistoryDBPort")
+   PortAttributeSensorAndConfigKey MODACLOUDS_HDB_PORT = new PortAttributeSensorAndConfigKey("modaclouds.hdb.port",
+           "MODAClouds History DB port", "31337");
+   
+   @SetFromFlag("modacloudsHistoryDBPath")
+   ConfigKey<String> MODACLOUDS_HDB_PATH = ConfigKeys.newStringConfigKey("modaclouds.hdb.path",
+           "DB URL path", "/ds");
 
-   @SetFromFlag("modacloudsKnowledgeBasePath")
-   BasicAttributeSensorAndConfigKey<String> MODACLOUDS_KB_PATH = new StringAttributeSensorAndConfigKey("modaclouds.kb.path", "MODAClouds Knowledge Base", "/modaclouds/kb");
-
-   @SetFromFlag("modacloudsKnowledgeBaseDatastore")
-   ConfigKey<String> MODACLOUDS_KB_DATASTORE_FOLDER = ConfigKeys.newStringConfigKey("modaclouds.kb.datastore",
-           "MODAClouds Knowledge Base Datastore", "/tmp");
-
-   AttributeSensor<URI> KB_CONSOLE_URI = Attributes.MAIN_URI;
+   @SetFromFlag("modacloudsHDBQueueIp")
+   ConfigKey<String> MODACLOUDS_HDBQUEUE_IP = ConfigKeys.newStringConfigKey("modaclouds.hdbqueue.ip",
+           "Queue endpoint IP address", "127.0.0.1");
+   
+   @SetFromFlag("modacloudsHDBQueuePort")
+   ConfigKey<String> MODACLOUDS_HDBQUEUE_PORT = ConfigKeys.newStringConfigKey("modaclouds.hdbqueue.port",
+           "Queue endpoint IP address", "5672");
+   
+   @SetFromFlag("modacloudsHDBListenerPath")
+   ConfigKey<String> MODACLOUDS_HDBLISTENER_PORT = ConfigKeys.newStringConfigKey("modaclouds.hdblistener.port",
+           "DB URL path", "/ds");
 
 }

--- a/usage/installer/src/main/java/eu/seaclouds/modaclouds/hdb/MODACloudsHistoryDBDriver.java
+++ b/usage/installer/src/main/java/eu/seaclouds/modaclouds/hdb/MODACloudsHistoryDBDriver.java
@@ -16,15 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package eu.seaclouds.modaclouds.kb;
+package eu.seaclouds.modaclouds.hdb;
 
 import brooklyn.entity.java.JavaSoftwareProcessDriver;
 
-public interface MODACloudsKnowledgeBaseDriver extends JavaSoftwareProcessDriver {
+public interface MODACloudsHistoryDBDriver extends JavaSoftwareProcessDriver {
 
    Integer getPort();
 
-   String getKnowledgeBasePath();
+   String getHistoryDBPath();
 
 
 }

--- a/usage/installer/src/main/java/eu/seaclouds/modaclouds/hdb/MODACloudsHistoryDBImpl.java
+++ b/usage/installer/src/main/java/eu/seaclouds/modaclouds/hdb/MODACloudsHistoryDBImpl.java
@@ -16,19 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package eu.seaclouds.modaclouds.kb;
+package eu.seaclouds.modaclouds.hdb;
 
 import brooklyn.entity.basic.SoftwareProcessImpl;
 
-public class MODACloudsKnowledgeBaseImpl extends SoftwareProcessImpl implements MODACloudsKnowledgeBase {
+public class MODACloudsHistoryDBImpl extends SoftwareProcessImpl implements MODACloudsHistoryDB {
    @Override
    public Class getDriverInterface() {
-      return eu.seaclouds.modaclouds.kb.MODACloudsKnowledgeBaseDriver.class;
+      return eu.seaclouds.modaclouds.hdb.MODACloudsHistoryDBDriver.class;
    }
 
    @Override
    public String getShortName() {
-      return "MODAClouds KB";
+      return "MODAClouds HDB";
    }
 
    @Override

--- a/usage/installer/src/main/java/eu/seaclouds/modaclouds/hdb/MODACloudsHistoryDBSshDriver.java
+++ b/usage/installer/src/main/java/eu/seaclouds/modaclouds/hdb/MODACloudsHistoryDBSshDriver.java
@@ -16,9 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package eu.seaclouds.modaclouds.kb;
+package eu.seaclouds.modaclouds.hdb;
 
 import static java.lang.String.format;
+
 import java.net.URI;
 import java.util.List;
 
@@ -34,9 +35,9 @@ import brooklyn.util.net.Networking;
 import brooklyn.util.os.Os;
 import brooklyn.util.ssh.BashCommands;
 
-public class MODACloudsKnowledgeBaseSshDriver extends JavaSoftwareProcessSshDriver implements MODACloudsKnowledgeBaseDriver {
+public class MODACloudsHistoryDBSshDriver extends JavaSoftwareProcessSshDriver implements MODACloudsHistoryDBDriver {
 
-   public MODACloudsKnowledgeBaseSshDriver(MODACloudsKnowledgeBaseImpl entity, SshMachineLocation machine) {
+   public MODACloudsHistoryDBSshDriver(MODACloudsHistoryDBImpl entity, SshMachineLocation machine) {
       super(entity, machine);
    }
 
@@ -48,7 +49,7 @@ public class MODACloudsKnowledgeBaseSshDriver extends JavaSoftwareProcessSshDriv
    @Override
    public void preInstall() {
       resolver = Entities.newDownloader(this);
-      setExpandedInstallDir(Os.mergePaths(getInstallDir(), resolver.getUnpackedDirectoryName(format("jena-fuseki-%s", getVersion()))));
+      setExpandedInstallDir(Os.mergePaths(getInstallDir(), resolver.getUnpackedDirectoryName(format("rdf-history-db-main-%s", getVersion()))));
    }
 
    @Override
@@ -70,16 +71,16 @@ public class MODACloudsKnowledgeBaseSshDriver extends JavaSoftwareProcessSshDriv
    @Override
    public void customize() {
       log.debug("Customizing {}", entity);
-      Networking.checkPortsValid(MutableMap.of("modacloudsKbPort", getPort()));
+      Networking.checkPortsValid(MutableMap.of("modacloudsHistoryDBPort", getPort()));
       newScript(CUSTOMIZING)
               .body.append(
               format("cp -R %s/* .", getExpandedInstallDir()),
-              format("mkdir %s/modaclouds-kb", getRunDir())
+              format("mkdir %s/modaclouds-hdb", getRunDir())
               ).execute();
    }
 
    public String getPidFile() {
-      return Os.mergePathsUnix(getRunDir(), "modaclouds-kb.pid");
+      return Os.mergePathsUnix(getRunDir(), "modaclouds-hdb.pid");
    }
 
    @Override
@@ -87,17 +88,24 @@ public class MODACloudsKnowledgeBaseSshDriver extends JavaSoftwareProcessSshDriv
       newScript(MutableMap.of(USE_PID_FILE, getPidFile()), LAUNCHING)
               .failOnNonZeroResultCode()
               .body.append(
-
-
-               format("nohup java -jar fuseki-server.jar --update --port %s --loc %s %s > %s 2>&1 &",
-               entity.getAttribute(MODACloudsKnowledgeBase.MODACLOUDS_KB_PORT),
-               entity.getConfig(MODACloudsKnowledgeBase.MODACLOUDS_KB_DATASTORE_FOLDER),
-                       entity.getAttribute(MODACloudsKnowledgeBase.MODACLOUDS_KB_PATH),
-               getLogFileLocation()))
-              .execute();
+		      format("nohup java -Xmx1200M -jar tower4clouds-rdf-history-db.jar " +
+		              "-queueip %s " +
+		              "-queueport %s " +
+		              "-dbpath %s " +
+		              "-dbport %s " +
+		              "-listenerport %s " +
+		              "> %s 2>&1 &",
+		      entity.getConfig(MODACloudsHistoryDB.MODACLOUDS_HDBQUEUE_IP),
+		      entity.getConfig(MODACloudsHistoryDB.MODACLOUDS_HDBQUEUE_PORT),
+		      entity.getConfig(MODACloudsHistoryDB.MODACLOUDS_HDB_PATH),
+		      entity.getConfig(MODACloudsHistoryDB.MODACLOUDS_HDBLISTENER_PORT),
+		      entity.getAttribute(MODACloudsHistoryDB.MODACLOUDS_HDB_PORT),
+		      getLogFileLocation()))
+		.execute();
+      
       String mainUri = String.format("http://%s:%d",
               entity.getAttribute(Attributes.HOSTNAME),
-              entity.getAttribute(MODACloudsKnowledgeBase.MODACLOUDS_KB_PORT));
+              entity.getAttribute(MODACloudsHistoryDB.MODACLOUDS_HDB_PORT));
       entity.setAttribute(Attributes.MAIN_URI, URI.create(mainUri));
    }
 
@@ -113,12 +121,12 @@ public class MODACloudsKnowledgeBaseSshDriver extends JavaSoftwareProcessSshDriv
 
    @Override
    public Integer getPort() {
-      return entity.getAttribute(MODACloudsKnowledgeBase.MODACLOUDS_KB_PORT);
+      return entity.getAttribute(MODACloudsHistoryDB.MODACLOUDS_HDB_PORT);
    }
 
    @Override
-   public String getKnowledgeBasePath() {
-      return entity.getConfig(MODACloudsKnowledgeBase.MODACLOUDS_KB_PATH);
+   public String getHistoryDBPath() {
+      return entity.getConfig(MODACloudsHistoryDB.MODACLOUDS_HDB_PATH);
    }
 
 }

--- a/usage/installer/src/main/java/eu/seaclouds/modaclouds/manager/MODACloudsMonitoringManager.java
+++ b/usage/installer/src/main/java/eu/seaclouds/modaclouds/manager/MODACloudsMonitoringManager.java
@@ -40,13 +40,13 @@ public interface MODACloudsMonitoringManager extends SoftwareProcess, HasShortNa
 
     @SetFromFlag("version")
     ConfigKey<String> SUGGESTED_VERSION =
-            ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.7");
+            ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.2");
 
     @SetFromFlag("downloadUrl")
     BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(
             SoftwareProcess.DOWNLOAD_URL,
-            "https://github.com/deib-polimi/modaclouds-monitoring-manager/releases/download/v${version}/monitoring-manager-${version}-distribution.tar.gz");
-
+            "https://github.com/deib-polimi/tower4clouds/releases/download/v${version}/manager-server-${version}.tar.gz");
+    
     @SetFromFlag("modacloudsMonitoringManagerPort")
     PortAttributeSensorAndConfigKey MODACLOUDS_MM_PORT = new PortAttributeSensorAndConfigKey("modaclouds.mm.port",
             "MODAClouds Monitoring Manager port", "8170+");
@@ -56,17 +56,11 @@ public interface MODACloudsMonitoringManager extends SoftwareProcess, HasShortNa
 
     @SetFromFlag("modacloudsDdaPort")
     ConfigKey<Integer> MODACLOUDS_DDA_PORT = ConfigKeys.newIntegerConfigKey("modaclouds.dda.port", "", 8175);
+    
+    @SetFromFlag("modacloudsHistoryDBIp")
+    ConfigKey<String> MODACLOUDS_HISTORYDB_IP = ConfigKeys.newStringConfigKey("modaclouds.historydb.ip", "127.0.0.1");
 
-    @SetFromFlag("modacloudsKbIp")
-    ConfigKey<String> MODACLOUDS_KB_IP = ConfigKeys.newStringConfigKey("modaclouds.kb.ip", "127.0.0.1");
-
-    @SetFromFlag("modacloudsKbPort")
-    ConfigKey<Integer> MODACLOUDS_KB_PORT = ConfigKeys.newIntegerConfigKey("modaclouds.kb.port", "", 3030);
-
-    @SetFromFlag("modacloudsKbDatasetPath")
-    ConfigKey<String> MODACLOUDS_KB_DATASET_PATH = ConfigKeys.newStringConfigKey("modaclouds.kb.dataset.path",
-            "/modaclouds/kb");
-
-   AttributeSensor<URI> KB_CONSOLE_URI = Attributes.MAIN_URI;
+    @SetFromFlag("modacloudsHistoryDBPort")
+    ConfigKey<Integer> MODACLOUDS_HISTORYDB_PORT = ConfigKeys.newIntegerConfigKey("modaclouds.historydb.port", "", 31337);
 
 }

--- a/usage/installer/src/main/java/eu/seaclouds/modaclouds/manager/MODACloudsMonitoringManagerSshDriver.java
+++ b/usage/installer/src/main/java/eu/seaclouds/modaclouds/manager/MODACloudsMonitoringManagerSshDriver.java
@@ -49,7 +49,7 @@ public class MODACloudsMonitoringManagerSshDriver extends JavaSoftwareProcessSsh
     @Override
     public void preInstall() {
         resolver = Entities.newDownloader(this);
-        setExpandedInstallDir(Os.mergePaths(getInstallDir(), resolver.getUnpackedDirectoryName(format("monitoring-manager-%s", getVersion()))));
+        setExpandedInstallDir(Os.mergePaths(getInstallDir(), resolver.getUnpackedDirectoryName(format("manager-server-%s", getVersion()))));
     }
 
     @Override
@@ -88,19 +88,17 @@ public class MODACloudsMonitoringManagerSshDriver extends JavaSoftwareProcessSsh
         newScript(MutableMap.of(USE_PID_FILE, getPidFile()), LAUNCHING)
                 .failOnNonZeroResultCode()
                 .body.append(
-                format("nohup java -jar monitoring-manager.jar " +
-                                "-ddaip %s " +
-                                "-ddaport %s " +
-                                "-kbip %s " +
-                                "-kbport %s " +
-                                "-kbpath %s " +
+                format("nohup java -Xmx1200M -jar tower4clouds-manager.jar " +
+                                "-daip %s " +
+                                "-daport %s " +
+                                "-rdf-history-db-ip %s " +
+                                "-rdf-history-db-port %s " +
                                 "-mmport %s " +
                                 "> %s 2>&1 &",
                         entity.getConfig(MODACloudsMonitoringManager.MODACLOUDS_DDA_IP),
                         entity.getConfig(MODACloudsMonitoringManager.MODACLOUDS_DDA_PORT),
-                        entity.getConfig(MODACloudsMonitoringManager.MODACLOUDS_KB_IP),
-                        entity.getConfig(MODACloudsMonitoringManager.MODACLOUDS_KB_PORT),
-                        entity.getConfig(MODACloudsMonitoringManager.MODACLOUDS_KB_DATASET_PATH),
+                        entity.getConfig(MODACloudsMonitoringManager.MODACLOUDS_HISTORYDB_IP),
+                        entity.getConfig(MODACloudsMonitoringManager.MODACLOUDS_HISTORYDB_PORT),
                         entity.getAttribute(MODACloudsMonitoringManager.MODACLOUDS_MM_PORT),
                         getLogFileLocation()))
                 .execute();

--- a/usage/installer/src/main/resources/brooklyn/entity/modaclouds/modaclouds-historydb.yaml
+++ b/usage/installer/src/main/resources/brooklyn/entity/modaclouds/modaclouds-historydb.yaml
@@ -6,9 +6,14 @@ services:
   name: server
   brooklyn.children:
 
+  - serviceType: eu.seaclouds.modaclouds.hdb.MODACloudsHistoryDB
+    name: MODAclouds History DB
+    id: hdb
+
   - serviceType: eu.seaclouds.modaclouds.dda.MODACloudsDeterministicDataAnalyzer
     name: MODAclouds Deterministic Data Analyzer
     id: dda
+    launch.latch: $brooklyn:component("hdb").attributeWhenReady("service.isUp")
 
   - serviceType: eu.seaclouds.modaclouds.manager.MODACloudsMonitoringManager
     name: MODAclouds Monitoring Manager
@@ -17,5 +22,7 @@ services:
     brooklyn.config:
       modaclouds.dda.ip: $brooklyn:component("dda").attributeWhenReady("host.address")
       modaclouds.dda.port: $brooklyn:component("dda").attributeWhenReady("modaclouds.dda.port")
+      modaclouds.hdb.ip: $brooklyn:component("hdb").attributeWhenReady("host.address")
+      modaclouds.hdb.port: $brooklyn:component("hdb").attributeWhenReady("modaclouds.hdb.port")
 
     launch.latch: $brooklyn:component("dda").attributeWhenReady("service.isUp")

--- a/usage/installer/src/main/resources/brooklyn/entity/modaclouds/modaclouds.yaml~
+++ b/usage/installer/src/main/resources/brooklyn/entity/modaclouds/modaclouds.yaml~
@@ -9,6 +9,7 @@ services:
   - serviceType: eu.seaclouds.modaclouds.dda.MODACloudsDeterministicDataAnalyzer
     name: MODAclouds Deterministic Data Analyzer
     id: dda
+    launch.latch: $brooklyn:component("hdb").attributeWhenReady("service.isUp")
 
   - serviceType: eu.seaclouds.modaclouds.manager.MODACloudsMonitoringManager
     name: MODAclouds Monitoring Manager

--- a/usage/installer/src/test/java/eu/seaclouds/modaclouds/kb/MODACloudsHistoryDBntegrationTest.java
+++ b/usage/installer/src/test/java/eu/seaclouds/modaclouds/kb/MODACloudsHistoryDBntegrationTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 
+import eu.seaclouds.modaclouds.hdb.MODACloudsHistoryDB;
 import brooklyn.entity.basic.Entities;
 import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.entity.trait.Startable;
@@ -33,7 +34,7 @@ import brooklyn.location.basic.LocalhostMachineProvisioningLocation;
 import brooklyn.test.EntityTestUtils;
 import brooklyn.test.entity.TestApplication;
 
-public class MODACloudsKnowledgeBaseIntegrationTest {
+public class MODACloudsHistoryDBntegrationTest {
 
     private TestApplication app;
     private LocalhostMachineProvisioningLocation localhostProvisioningLocation;
@@ -51,7 +52,7 @@ public class MODACloudsKnowledgeBaseIntegrationTest {
 
     @Test(groups = "Integration")
     public void testCanStartAndStop() throws Exception {
-        MODACloudsKnowledgeBase entity = app.createAndManageChild(EntitySpec.create(MODACloudsKnowledgeBase.class));
+        MODACloudsHistoryDB entity = app.createAndManageChild(EntitySpec.create(MODACloudsHistoryDB.class));
         app.start(ImmutableList.of(localhostProvisioningLocation));
 
         EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);


### PR DESCRIPTION
@perezp @andreaturli @rosogon 

MODAClouds Brooklyn entities modified in order to support the the new version of the monitoring, TOWER4 CLouds:

- modified ssh driver and the main class the data analyzer entities to retrieve release 0.2 and be able to launch and configure it with the available parameters
- modified ssh driver and the main class within the monitoring manager entities to retrieve  release 0.2 from tower4clouds repo and be able to launch and configure it with the available parameters
- converted all the knoledge base entities into the history db entities. Now it is possible to retrive release 0.2 of the history dbfrom tower4clouds repo and to launch and configure it with the available parameters