### PR TITLE
FEATURE: Adding CloudFoundry support to the deployer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <guava.version>18.0</guava.version>
         <javatuples.version>1.2</javatuples.version>
-        <brooklyn.version>0.7.0-20150614.2158</brooklyn.version>
+        <brooklyn.version>0.8.0-SNAPSHOT</brooklyn.version>
         <jetty.version>9.2.4.v20141103</jetty.version>
         <dropwizard.version>0.8.1</dropwizard.version>
         <junit.version>4.11</junit.version>

--- a/usage/installer/src/main/assembly/files/blueprints/seaclouds-on-byon.yaml
+++ b/usage/installer/src/main/assembly/files/blueprints/seaclouds-on-byon.yaml
@@ -19,12 +19,13 @@ services:
   - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
     id: deployer
     name: SeaClouds Deployer
-    install.version: 0.7.0-SNAPSHOT
     managementUser: admin
     managementPassword: p4ssw0rd
     brooklynLocalPropertiesContents: |
       brooklyn.webconsole.security.users=admin
       brooklyn.webconsole.security.user.admin.password=p4ssw0rd
+    brooklyn.config:
+      download.url: https://github.com/kiuby88/incubator-brooklyn/releases/download/v0.8.0-cf/brooklyn-dist-0.8.0-SNAPSHOT-dist.tar.gz
 
 - serviceType: brooklyn.entity.basic.SameServerEntity
   name: SeaClouds Dashboard + Planner + SLA

--- a/usage/installer/src/main/assembly/files/blueprints/seaclouds.yaml
+++ b/usage/installer/src/main/assembly/files/blueprints/seaclouds.yaml
@@ -10,12 +10,13 @@ services:
 - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
   id: deployer
   name: SeaClouds Deployer
-  install.version: 0.7.0-SNAPSHOT
   managementUser: admin
   managementPassword: p4ssw0rd
   brooklynLocalPropertiesContents: |
     brooklyn.webconsole.security.users=admin
     brooklyn.webconsole.security.user.admin.password=p4ssw0rd
+  brooklyn.config:
+    download.url: https://github.com/kiuby88/incubator-brooklyn/releases/download/v0.8.0-cf/brooklyn-dist-0.8.0-SNAPSHOT-dist.tar.gz
 
 - serviceType: eu.seaclouds.dashboard.SeacloudsDashboard
   name: SeaClouds Dashboard


### PR DESCRIPTION
The deployer uses a custom Brooklyn distribution which contains the CloudFoundry support.

The version of Brooklyn which is being used to deploy SeaCloudsPlatform was uploaded to `0.8.0-SNAPSHOT`. Previously, we used a fix SNAPSHOT version of `0.7.0`, so probably we should to fix a `0.8.0` version but currently there is not any available at any of the Brooklyn snapshot repositories.

Currently, the Deployer is using a custom distribution of Brooklyn which contains the CloudFoundry support (entities and location). This [custom version](https://github.com/kiuby88/incubator-brooklyn/releases) is stored in my SeaClouds/incubator-brooklyn fork. It is a temporal solution, we are working on the total integration of CloudFoundry features into [apache/incubator-brooklyn](https://github.com/apache/incubator-brooklyn).

Thanks @mbarrientos for the support.


