### PR TITLE
FIX(usage): Added T4C env vars to sla core

### DIFF
--- a/usage/installer/src/main/assembly/files/blueprints/seaclouds-on-byon.yaml
+++ b/usage/installer/src/main/assembly/files/blueprints/seaclouds-on-byon.yaml
@@ -19,15 +19,12 @@ services:
   - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
     id: deployer
     name: SeaClouds Deployer
+    install.version: 0.7.0-SNAPSHOT
     managementUser: admin
     managementPassword: p4ssw0rd
     brooklynLocalPropertiesContents: |
       brooklyn.webconsole.security.users=admin
       brooklyn.webconsole.security.user.admin.password=p4ssw0rd
-    brooklyn.config:
-      brooklynnode.download.archive.subpath: brooklyn-dist-0.7.0-incubating/
-      brooklynnode.classpath:
-        - classpath://deployer-0.8.0-SNAPSHOT.jar
 
 - serviceType: brooklyn.entity.basic.SameServerEntity
   name: SeaClouds Dashboard + Planner + SLA
@@ -61,6 +58,13 @@ services:
                 component("sla-db").attributeWhenReady("datastore.url"), "sc_sla")
             DB_USERNAME: "atossla"
             DB_PASSWORD: "_atossla_"
+            MONITOR_METRICS_URL: >
+                $brooklyn:formatString("%s/v1/metrics", 
+                component("monitoring").component("child", "manager").attributeWhenReady("main.uri"))
+            SLA_URL: >
+                $brooklyn:formatString("http://%s:%s", 
+                component("sla-core").attributeWhenReady("host.address"), 
+                component("sla-core").attributeWhenReady("http.port"))
       war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=sla-service&v=LATEST&e=war
       install.latch: $brooklyn:component("sla-db").attributeWhenReady("service.isUp")
 

--- a/usage/installer/src/main/assembly/files/blueprints/seaclouds-on-byon.yaml
+++ b/usage/installer/src/main/assembly/files/blueprints/seaclouds-on-byon.yaml
@@ -19,12 +19,15 @@ services:
   - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
     id: deployer
     name: SeaClouds Deployer
-    install.version: 0.7.0-SNAPSHOT
     managementUser: admin
     managementPassword: p4ssw0rd
     brooklynLocalPropertiesContents: |
       brooklyn.webconsole.security.users=admin
       brooklyn.webconsole.security.user.admin.password=p4ssw0rd
+    brooklyn.config:
+      brooklynnode.download.archive.subpath: brooklyn-dist-0.7.0-incubating/
+      brooklynnode.classpath:
+        - classpath://deployer-0.8.0-SNAPSHOT.jar
 
 - serviceType: brooklyn.entity.basic.SameServerEntity
   name: SeaClouds Dashboard + Planner + SLA

--- a/usage/installer/src/main/assembly/files/blueprints/seaclouds.yaml
+++ b/usage/installer/src/main/assembly/files/blueprints/seaclouds.yaml
@@ -10,16 +10,12 @@ services:
 - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
   id: deployer
   name: SeaClouds Deployer
+  install.version: 0.7.0-SNAPSHOT
   managementUser: admin
   managementPassword: p4ssw0rd
   brooklynLocalPropertiesContents: |
     brooklyn.webconsole.security.users=admin
     brooklyn.webconsole.security.user.admin.password=p4ssw0rd
-  brooklyn.config:
-    brooklynnode.download.archive.subpath: brooklyn-dist-0.7.0-incubating/
-    brooklynnode.classpath:
-      - classpath://deployer-0.8.0-SNAPSHOT.jar
-
 
 - serviceType: eu.seaclouds.dashboard.SeacloudsDashboard
   name: SeaClouds Dashboard
@@ -49,6 +45,13 @@ services:
               component("sla-db").attributeWhenReady("datastore.url"), "sc_sla")
           DB_USERNAME: "atossla"
           DB_PASSWORD: "_atossla_"
+          MONITOR_METRICS_URL: >
+              $brooklyn:formatString("%s/v1/metrics", 
+              component("monitoring").component("child", "manager").attributeWhenReady("main.uri"))
+          SLA_URL: >
+              $brooklyn:formatString("http://%s:%s", 
+              component("sla-core").attributeWhenReady("host.address"), 
+              component("sla-core").attributeWhenReady("http.port"))
     war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=sla-service&v=LATEST&e=war
   - serviceType: brooklyn.entity.database.mysql.MySqlNode
     id: sla-db

--- a/usage/installer/src/main/assembly/files/blueprints/seaclouds.yaml
+++ b/usage/installer/src/main/assembly/files/blueprints/seaclouds.yaml
@@ -10,12 +10,16 @@ services:
 - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
   id: deployer
   name: SeaClouds Deployer
-  install.version: 0.7.0-SNAPSHOT
   managementUser: admin
   managementPassword: p4ssw0rd
   brooklynLocalPropertiesContents: |
     brooklyn.webconsole.security.users=admin
     brooklyn.webconsole.security.user.admin.password=p4ssw0rd
+  brooklyn.config:
+    brooklynnode.download.archive.subpath: brooklyn-dist-0.7.0-incubating/
+    brooklynnode.classpath:
+      - classpath://deployer-0.8.0-SNAPSHOT.jar
+
 
 - serviceType: eu.seaclouds.dashboard.SeacloudsDashboard
   name: SeaClouds Dashboard


### PR DESCRIPTION
These lines were missing from the master.  

I'm not sure if they are still valid. F.e., deployer uses $brooklyn:component("monitoring").component("child","manager"), instead of directly component("manager").
 