### PR TITLE
Workaround to allow the wizard to skip the matchmake/optimization/dam-generation step.

### DIFF
--- a/dashboard/src/main/resources/webapp/projects/add-application-wizard/add-application-wizard.html
+++ b/dashboard/src/main/resources/webapp/projects/add-application-wizard/add-application-wizard.html
@@ -49,6 +49,8 @@
             <button type="button" class="btn btn-default btn-primary" ng-click='nextStep()'
                     ng-disabled="!wizardCanContinue()" ng-if="currentStep < 4">Next
             </button>
+            <button type="button" class="btn btn-default btn-warning" ng-click='nextStep()' ng-if="currentStep == 3">Skip step
+            </button>
             <button type="button" class="btn btn-default btn-success" ng-click='nextStep()'
                     ng-disabled="!wizardCanContinue()" ng-if="currentStep == 4">Deploy
             </button>


### PR DESCRIPTION
This will allow to the dashboard to skip the third step to be able to deploy applications with seaclouds if the user already has all the neccessary inputs (Deployment yaml, monitoring rules and sla agreements).

@andreaturli  could you take a look?