### PR TITLE
integrate planner yaml

### DIFF
--- a/usage/installer/README.md
+++ b/usage/installer/README.md
@@ -1,36 +1,45 @@
 # SeaClouds
 
 ## Deploy SeaClouds
-A deployment of SeaClouds can be launched using Apache Brooklyn. We currently support deployments against Bring Your 
+A deployment of SeaClouds can be launched using Apache Brooklyn. We currently support deployments against Bring Your
 Own Nodes (BYON) and to all the IaaS provider supported by [Apache jclouds](http://jclouds.org).
 
+# Launching SeaClouds platform
 
-# Deploy SeaClouds platform
+- download from `https://oss.sonatype.org/content/repositories/snapshots/eu/seaclouds-project/installer/0.8.0-SNAPSHOT/`
+the latest `installer-0.8.0-*-dist.tar.gz`
+- unpack it: `tar xzf installer-0.8.0-*-dist.tar.gz`
 
-Make sure you have [Apache Maven](https://maven.apache.org/) v.3.5.5+
-
-First of all you need to build the SeaCloudsPlatform project with:
-
-```bash
-mvn clean install -DskipTests
-```
-
-## Launching SeaClouds on the cloud
+## Deploying SeaClouds on the cloud
 
 ```bash
-cd usage/installer/target/seaclouds-installer-dist/seaclouds-installer
-nohup ./start.sh --app blueprints/seaclouds.yaml --location <location> &
+cd seaclouds-installer
 ```
 
-## Launching SeaClouds on BYON
+Open `blueprints/seaclouds.yaml` and add a location to the blueprint, similar to:
+
+```
+location:
+  jclouds:aws-ec2:eu-west-1:
+    identity: ABCDEFGHIJKLMNOPQRST
+    credential: s3cr3tsq1rr3ls3cr3tsq1rr3ls3cr3tsq1rr3l
+    imageId: eu-west-1/ami-f3f6d784
+```
+and then run:
+
+```
+nohup ./start.sh --app blueprints/seaclouds.yaml &
+```
+
+## Deploying SeaClouds on BYON
 
 Make sure you have [Vagrant](https://www.vagrantup.com/), [Virtual Box](https://www.virtualbox.org/)
 
 ```bash
-cd usage/installer/target/seaclouds-installer-dist/seaclouds-installer
+cd seaclouds-installer
 pushd .
 cd byon
-vagrant up 
+vagrant up
 popd
 nohup ./start.sh &
 tail -f nohup.out
@@ -46,18 +55,59 @@ nohup ./start.sh --app blueprints/seaclouds-on-byon.yaml &
 tail -f nohup.out
 ```
 
-### SeaClouds release 0.7.0-M19
+# Building standalone SeaClouds distro
 
-A detailed description of [0.7.0-M19](https://github.com/SeaCloudsEU/SeaCloudsPlatform/releases/tag/0.7.0-M19) SeaClouds release including: 
+Make sure you have [Apache Maven](https://maven.apache.org/) v.3.5.5+
+
+First of all you need to build the SeaCloudsPlatform project with:
+
+```bash
+mvn clean install -DskipTests
+```
+
+## Deploying SeaClouds on the cloud
+
+```bash
+cd usage/installer/target/seaclouds-installer-dist/seaclouds-installer
+nohup ./start.sh --app blueprints/seaclouds.yaml --location <location> &
+```
+
+## Deploying SeaClouds on BYON
+
+Make sure you have [Vagrant](https://www.vagrantup.com/), [Virtual Box](https://www.virtualbox.org/)
+
+```bash
+cd usage/installer/target/seaclouds-installer-dist/seaclouds-installer
+pushd .
+cd byon
+vagrant up
+popd
+nohup ./start.sh &
+tail -f nohup.out
+```
+This spins up a virtual environment, made up of 2 VMs, that is accessible at `192.168.100.10` and `192.168.100.11`.
+
+Finally, copy and paste [seaclouds blueprint](./src/main/assembly/files/blueprints/seaclouds-on-byon.yaml) to deploy the SeaClouds platform on the 2 VMs.
+
+If you prefer you can also launch the platform deployment from CLI
+
+```bash
+nohup ./start.sh --app blueprints/seaclouds-on-byon.yaml &
+tail -f nohup.out
+```
+
+## SeaClouds release 0.7.0-M19
+
+A detailed description of [0.7.0-M19](https://github.com/SeaCloudsEU/SeaCloudsPlatform/releases/tag/0.7.0-M19) SeaClouds release including:
 - SeaClouds components and their interactions
-- A guide to get an install SeaClouds Platform 
+- A guide to get an install SeaClouds Platform
 - An example of how to use SeaClouds Platform and exploit its capabilities and the capabilies of each of its components
 
 can be found in the [Integrated Platform deliverable](https://drive.google.com/file/d/0B3naRHlVBGTEdmYySFVWSGdIYzA/view?usp=sharing).
 
 ### Troubleshooting
 
-When deploying SeaClouds platform an [Apache Brooklyn](http://brooklyn.io) instance will be started on your 
+When deploying SeaClouds platform an [Apache Brooklyn](http://brooklyn.io) instance will be started on your
 workstation, accessible at `http://localhost:8081` by default. Please double-check in nohup.out the correct url.
 
 You may need to update the `privateKeyFile` property in the blueprint to the actual path.

--- a/usage/installer/src/main/assembly/files/blueprints/seaclouds-on-byon.yaml
+++ b/usage/installer/src/main/assembly/files/blueprints/seaclouds-on-byon.yaml
@@ -13,22 +13,18 @@ services:
   name: SeaClouds Deployer + Monitoring
   brooklyn.children:
   - serviceType: eu.seaclouds.modaclouds.dda.MODACloudsDeterministicDataAnalyzer
-    name: MODAclouds Deterministic Data Analyzer
+    name: Monitoring DDA
     id: monitoring-dda
   - serviceType: eu.seaclouds.modaclouds.manager.MODACloudsMonitoringManager
-    name: MODAclouds Monitoring Manager
+    name: Monitoring Manager
     id: monitoring-manager
     brooklyn.config:
       modaclouds.dda.ip: $brooklyn:component("monitoring-dda").attributeWhenReady("host.address")
   - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
     id: deployer
-    name: SeaClouds Deployer
-    managementUser: admin
-    managementPassword: p4ssw0rd
-    brooklynLocalPropertiesContents: |
-      brooklyn.webconsole.security.users=admin
-      brooklyn.webconsole.security.user.admin.password=p4ssw0rd
+    name: Deployer
     brooklyn.config:
+      brooklynnode.webconsole.nosecurity: true
       brooklynnode.download.archive.subpath: brooklyn-dist-0.7.0-incubating/
       brooklynnode.classpath:
         - classpath://deployer-0.8.0-SNAPSHOT.jar
@@ -38,26 +34,31 @@ services:
 
   shell.env:
     SLA_HOST: $brooklyn:component("sla-core").attributeWhenReady("host.address")
-    SLA_PORT: $brooklyn:component("sla-core").attributeWhenReady("http.port")  
-  
+    SLA_PORT: $brooklyn:component("sla-core").attributeWhenReady("http.port")
+
   brooklyn.children:
   - serviceType: eu.seaclouds.dashboard.SeacloudsDashboard
-    name: SeaClouds Dashboard
-    id: dashboard  
+    name: Dashboard
+    id: dashboard
     brooklyn.config:
       port: 8000
       adminPort: 8001
       deployerHost: $brooklyn:component("deployer").attributeWhenReady("host.address")
       deployerPort: $brooklyn:component("deployer").attributeWhenReady("brooklynnode.webconsole.httpPort")
-      deployerUser: $brooklyn:component("deployer").config("brooklynnode.managementUser")
-      deployerPassword: $brooklyn:component("deployer").config("brooklynnode.managementPassword")
       slaHost: $SLA_HOST
       monitorHost: $brooklyn:component("monitoring-manager").attributeWhenReady("host.address")
-      monitorPort: $brooklyn:component("monitoring-manager").attributeWhenReady("modaclouds.mm.port")      
+      monitorPort: $brooklyn:component("monitoring-manager").attributeWhenReady("modaclouds.mm.port")
     install.latch: $brooklyn:component("sla-core").attributeWhenReady("service.isUp")
-    
+
+  - serviceType: "classpath://eu.seaclouds.planner/planner_blueprint.yml"
+    id: planner
+    name: Planner
+    brooklyn.config:
+        planner.install.version: "0.8.0-20150918.142713-9"
+    launch.latch: $brooklyn:component("sla-core").attributeWhenReady("service.isUp")
+
   - serviceType: brooklyn.entity.webapp.tomcat.TomcatServer
-    name: SLA service Core
+    name: SLA Core
     id: sla-core
     brooklyn.config:
       java.sysprops:
@@ -70,6 +71,6 @@ services:
 
   - serviceType: brooklyn.entity.database.mysql.MySqlNode
     id: sla-db
-    name: SLA service Db
+    name: SLA Db
     brooklyn.config:
       creationScriptUrl: https://raw.githubusercontent.com/SeaCloudsEU/sla-core/e1d3bd4dec27236cfdefa1eae81d38db3dcd11da/sla-repository/src/main/resources/sql/01database.sql

--- a/usage/installer/src/main/assembly/files/blueprints/seaclouds.yaml
+++ b/usage/installer/src/main/assembly/files/blueprints/seaclouds.yaml
@@ -4,61 +4,61 @@ name: SeaClouds platform
 # location:
 
 services:
-- serviceType: "classpath://brooklyn/entity/modaclouds/modaclouds.yaml"
-  id: monitoring
-  name: SeaClouds Monitoring
+- serviceType: eu.seaclouds.modaclouds.dda.MODACloudsDeterministicDataAnalyzer
+  name: Monitoring DDA
+  id: monitoring-dda
+- serviceType: eu.seaclouds.modaclouds.manager.MODACloudsMonitoringManager
+  name: Monitoring Manager
+  id: monitoring-manager
+  brooklyn.config:
+    modaclouds.dda.ip: $brooklyn:component("monitoring-dda").attributeWhenReady("host.address")
 - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
   id: deployer
-  name: SeaClouds Deployer
-  managementUser: admin
-  managementPassword: p4ssw0rd
-  brooklynLocalPropertiesContents: |
-    brooklyn.webconsole.security.users=admin
-    brooklyn.webconsole.security.user.admin.password=p4ssw0rd
+  name: Deployer
   brooklyn.config:
+    brooklynnode.webconsole.nosecurity: true
     brooklynnode.download.archive.subpath: brooklyn-dist-0.7.0-incubating/
     brooklynnode.classpath:
       - classpath://deployer-0.8.0-SNAPSHOT.jar
 
-
 - serviceType: eu.seaclouds.dashboard.SeacloudsDashboard
-  name: SeaClouds Dashboard
+  name: Dashboard
   id: dashboard
-  brooklyn.config: 
+  shell.env:
+    SLA_HOST: $brooklyn:component("sla-core").attributeWhenReady("host.address")
+    SLA_PORT: $brooklyn:component("sla-core").attributeWhenReady("http.port")
+  brooklyn.config:
     port: 8000
     adminPort: 8001
     deployerHost: $brooklyn:component("deployer").attributeWhenReady("host.address")
     deployerPort: $brooklyn:component("deployer").attributeWhenReady("brooklynnode.webconsole.httpPort")
     deployerUser: $brooklyn:component("deployer").config("brooklynnode.managementUser")
     deployerPassword: $brooklyn:component("deployer").config("brooklynnode.managementPassword")
-    monitorHost: $brooklyn:component("monitoring").component("child","manager").attributeWhenReady("host.address")
-    monitorPort: $brooklyn:component("monitoring").component("child","manager").attributeWhenReady("modaclouds.mm.port")
-    slaHost: $brooklyn:component("sla-core").attributeWhenReady("host.address")
-    slaPort: $brooklyn:component("sla-core").attributeWhenReady("http.port")
-    
-- serviceType: brooklyn.entity.basic.SameServerEntity
-  name: SeaClouds SLA
-  brooklyn.children:
-  - serviceType: brooklyn.entity.webapp.tomcat.TomcatServer
-    name: SLA Core
-    id: sla-core
-    brooklyn.config:
-      java.sysprops:
-          DB_URL: >
-              $brooklyn:formatString("jdbc:%s%s",
-              component("sla-db").attributeWhenReady("datastore.url"), "sc_sla")
-          DB_USERNAME: "atossla"
-          DB_PASSWORD: "_atossla_"
-          MONITOR_METRICS_URL: >
-              $brooklyn:formatString("%s/v1/metrics", 
-              component("monitoring").component("child", "manager").attributeWhenReady("main.uri"))
-          SLA_URL: >
-              $brooklyn:formatString("http://%s:%s", 
-              component("sla-core").attributeWhenReady("host.address"), 
-              component("sla-core").attributeWhenReady("http.port"))
-    war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=sla-service&v=LATEST&e=war
-  - serviceType: brooklyn.entity.database.mysql.MySqlNode
-    id: sla-db
-    name: SLA Db
-    brooklyn.config:
-      creationScriptUrl: https://raw.githubusercontent.com/SeaCloudsEU/sla-core/e1d3bd4dec27236cfdefa1eae81d38db3dcd11da/sla-repository/src/main/resources/sql/01database.sql
+    slaHost: $SLA_HOST
+    monitorHost: $brooklyn:component("monitoring-manager").attributeWhenReady("host.address")
+    monitorPort: $brooklyn:component("monitoring-manager").attributeWhenReady("modaclouds.mm.port")
+  install.latch: $brooklyn:component("sla-core").attributeWhenReady("service.isUp")
+
+- serviceType: "classpath://eu.seaclouds.planner/planner_blueprint.yml"
+  id: planner
+  name: Planner
+  brooklyn.config:
+      planner.install.version: "0.8.0-20150918.142713-9"
+
+- serviceType: brooklyn.entity.webapp.tomcat.TomcatServer
+  name: SLA Core
+  id: sla-core
+  brooklyn.config:
+    java.sysprops:
+        DB_URL: $brooklyn:formatString("jdbc:%s%s", component("sla-db").attributeWhenReady("datastore.url"), "sc_sla")
+        DB_USERNAME: "atossla"
+        DB_PASSWORD: "_atossla_"
+        MONITOR_METRICS_URL: $brooklyn:formatString("%s/v1/metrics", component("monitoring-manager").attributeWhenReady("main.uri"))
+        SLA_URL: $brooklyn:formatString("http://%s:%s", component("sla-core").attributeWhenReady("host.address"), component("sla-core").attributeWhenReady("http.port"))
+  war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=sla-service&v=LATEST&e=war
+
+- serviceType: brooklyn.entity.database.mysql.MySqlNode
+  id: sla-db
+  name: SLA Db
+  brooklyn.config:
+    creationScriptUrl: https://raw.githubusercontent.com/SeaCloudsEU/sla-core/e1d3bd4dec27236cfdefa1eae81d38db3dcd11da/sla-repository/src/main/resources/sql/01database.sql


### PR DESCRIPTION
- add planner to seaclouds-on-byon.yaml
- remove authN from deployer
- fix seaclouds.yaml blueprint (deployed on AWS EC2)