### PR TITLE
Added Brooklyn entities for PHP applications.

### DIFF
--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -55,6 +55,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-software-webapp</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-software-database</artifactId>
+        </dependency>
+        
+        <dependency>
             <groupId>org.cloudfoundry</groupId>
             <artifactId>cloudfoundry-client-lib</artifactId>
         </dependency>

--- a/deployer/src/main/java/org/apache/brooklyn/entity/SourceNameResolver.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/SourceNameResolver.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity;
+
+
+
+public class SourceNameResolver {
+
+    public static String getNameOfRepositoryGitFromHttpsUrl(String url){
+        String nameOfRepository="";
+        nameOfRepository=url.substring(url.lastIndexOf("/")+1, url.lastIndexOf("."));
+        return nameOfRepository;
+    }
+
+    /**
+     * Return the id of the resource pointed by the url without extension
+     * E.g. http://example.com/resource.tar return resource
+     * @param url
+     * @return
+     */
+
+    public static String getIdOfTarballFromUrl(String url){
+        String nameOfTarballResource=getTarballResourceNameFromUrl(url);
+        return nameOfTarballResource.substring(0,nameOfTarballResource.lastIndexOf("."));
+    }
+
+    /**
+     * Return the name of the tarball resource.
+     * E.g. http://example.com/resource.tar return resource.tar
+     * @param url
+     * @return
+     */
+    public static String getTarballResourceNameFromUrl(String url) {
+        String resourceName = url.substring(url.lastIndexOf('/') + 1);
+        return resourceName;
+    }
+
+
+
+
+
+}

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppDriver.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppDriver.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.php;
+
+import java.util.Set;
+import org.apache.brooklyn.entity.software.base.SoftwareProcessDriver;
+import org.apache.brooklyn.entity.webapp.HttpsSslConfig;
+
+
+public interface PhpWebAppDriver extends SoftwareProcessDriver {
+
+    Set<String> getEnabledProtocols();
+
+    Integer getHttpPort();
+
+    Integer getHttpsPort();
+
+    HttpsSslConfig getHttpsSslConfig();
+
+    String deployGitResource(String url, String targetName);
+
+    String deployTarballResource(String url, String targetName);
+
+    void undeploy(String targetName);
+
+}

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppService.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppService.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.php;
+
+import java.util.List;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.BasicConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.MapConfigKey;
+import org.apache.brooklyn.entity.webapp.WebAppService;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+
+
+public interface PhpWebAppService extends WebAppService {
+
+    @SetFromFlag("tarball.url")
+    public static final ConfigKey<String> TARBALL_URL = new BasicConfigKey<String>(
+            String.class, "php.tarball.url ", "The path where the deploment artifact (tarball) is stored (supporting file: and classpath: prefixes)");
+
+    @SetFromFlag("git.url")
+    public static final ConfigKey<String> GIT_URL = new BasicConfigKey<String>(
+            String.class, "php.git.url ", "The Git repository where the application source code is stored (gitRepo)");
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SetFromFlag("app.name")
+    public static final ConfigKey<String> APP_NAME = new BasicConfigKey(
+            String.class, "php.app.name", "The name of the PHP application");
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SetFromFlag("main.file")
+    public static final ConfigKey<List<String>> APP_START_FILE = new BasicConfigKey(
+            List.class, "php.app.start.file", "PHP application file to start e.g. main.php, or launch.php");
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SetFromFlag("config.file.template")
+    public static final ConfigKey<String> CONFIG_FILE_TEMPLATE = new BasicConfigKey(
+            String.class, "php.config.template", "The name of the PHP application");
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SetFromFlag("config.file")
+    public static final ConfigKey<String> CONFIG_FILE = new BasicConfigKey(
+            String.class, "php.db.connection.file.config", "The name of the PHP application");
+    
+    @SetFromFlag("config.params")
+    public static final MapConfigKey<String> PHP_CONFIG_PARAMS = new MapConfigKey<String>(String.class,
+            "php.config.params", "Configuration parameters to be replaced on {CONFIG_FILE}.");
+
+    @SetFromFlag("php.version")
+    public static final ConfigKey<String> SUGGESTED_PHP_VERSION = ConfigKeys.newStringConfigKey(
+            "php.version", "PHP version used", "5.5.9");
+
+
+}

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppSoftwareProcess.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppSoftwareProcess.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.php;
+
+
+import java.util.Set;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.annotation.Effector;
+import org.apache.brooklyn.core.annotation.EffectorParam;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.MethodEffector;
+import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+
+
+@ImplementedBy(PhpWebAppSoftwareProcessImpl.class)
+public interface PhpWebAppSoftwareProcess extends SoftwareProcess, PhpWebAppService {
+
+    public static final AttributeSensor<Set<String>> DEPLOYED_PHP_APPS = new BasicAttributeSensor(
+            Set.class, "webapp.deployedApps", "Names of archives/contexts that are currently deployed");
+    public static final MethodEffector<Void> DEPLOY_GIT_RESOURCE = new MethodEffector<Void>(PhpWebAppSoftwareProcess.class, "deployGitResource");
+    public static final MethodEffector<Void> DEPLOY_TARBALL_RESOURCE = new MethodEffector<Void>(PhpWebAppSoftwareProcess.class, "deployTarballResource");
+    public static final MethodEffector<Void> UNDEPLOY = new MethodEffector<Void>(PhpWebAppSoftwareProcess.class, "undeploy");
+
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.4");
+
+    /**
+     * It deploys an application which is stored in a git repository.
+     * The repo is cloned using the name specified by the targetName.
+     * So, the target name is used as id to deploy the application in the server.
+     *
+     * @param url        A url of the git repo where the application are stored. Currently, https url are supported.
+     * @param targetName name of the application used to deploy it.
+     */
+    @Effector(description = "Deploys the given artifact, from a source URL, to a given deployment filename/context")
+    public void deployGitResource(
+            @EffectorParam(name = "url", description = "URL of git Repo file") String url,
+            @EffectorParam(name = "targetName", description = "Application Name") String targetName);
+
+    /**
+     * It deploys an application which is packaged like a tarball from a url.
+     * The application is downloaded and unpackaged in the folder specified by the targetName.
+     *
+     * @param url        A url of the tarball resource where the application are stored.
+     * @param targetName name of the application used to deploy it.
+     */
+    @Effector(description = "Deploys the given artifact, from a source URL, to a given deployment filename/context")
+    public void deployTarballResource(
+            @EffectorParam(name = "url", description = "URL of tarball resource") String url,
+            @EffectorParam(name = "targetName", description = "Application Name") String targetName);
+
+    /**
+     * For the DEPLOYED_PHP_APP to be updated, the input must match the result of the call to deploy
+     */
+    @Effector(description = "Undeploys the given context/artifact")
+    public void undeploy(
+            @EffectorParam(name = "targetName") String targetName);
+
+}

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppSoftwareProcessImpl.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppSoftwareProcessImpl.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.php;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.Sets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.entity.SourceNameResolver;
+import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
+import org.apache.brooklyn.entity.webapp.WebAppServiceMethods;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public abstract class PhpWebAppSoftwareProcessImpl extends SoftwareProcessImpl implements PhpWebAppSoftwareProcess {
+    private static final Logger LOG = LoggerFactory.getLogger(PhpWebAppSoftwareProcessImpl.class);
+
+    public PhpWebAppSoftwareProcessImpl() {
+        super();
+    }
+
+    public PhpWebAppSoftwareProcessImpl(Entity parent) {
+        this(new LinkedHashMap(), parent);
+    }
+
+    public PhpWebAppSoftwareProcessImpl(Map flags) {
+        this(flags, null);
+    }
+
+    public PhpWebAppSoftwareProcessImpl(Map flags, Entity parent) {
+        super(flags, parent);
+    }
+
+    public PhpWebAppDriver getDriver() {
+        return (PhpWebAppDriver) super.getDriver();
+    }
+
+    protected Set<String> getEnabledProtocols() {
+        return getAttribute(PhpWebAppSoftwareProcess.ENABLED_PROTOCOLS);
+    }
+
+    protected Set<String> getDeployedApps() {
+        return getAttribute(DEPLOYED_PHP_APPS);
+    }
+    
+    protected void setDeployedApps(Set<String> deployedPhpApps) {
+        setAttribute(DEPLOYED_PHP_APPS, deployedPhpApps);
+    }
+    
+    protected int getHttpPort() {
+        return getAttribute(HTTP_PORT);
+    }
+
+    public String getAppName() {
+        return getConfig(APP_NAME);
+    }
+    
+    @Override
+    protected void connectSensors() {
+        super.connectSensors();
+        WebAppServiceMethods.connectWebAppServerPolicies(this);
+    }
+
+
+    @Override
+    protected void preStop(){
+        super.preStop();
+        //zero our workrate derived workrates.
+        //TODO might not be enough, as a policy may still be executing and have a record of historic vals;
+        // should remove policies
+        // also nor sure we want this; implies more generally a resposibility for sensor to announce things
+        // disconnected
+        
+        // Resetting sensor values
+        setAttribute(REQUESTS_PER_SECOND_LAST, 0D);
+        setAttribute(REQUESTS_PER_SECOND_IN_WINDOW, 0D);
+    }
+
+    // TODO thread-safety issues: if multiple concurrent calls, may break (e.g. deployment_wars being reset)
+    public void deployInitialApplications() {
+        initDeployAppAttributeIfIsNull();
+
+        String gitRepoUrl = getConfig(GIT_URL);
+        String tarballResourceUrl = getConfig(TARBALL_URL);
+        
+        if (gitRepoUrl != null) {
+            String targetName = inferCorrectAppGitName();
+            deployGitResource(gitRepoUrl, targetName);
+        } else if (tarballResourceUrl != null) {
+            String targetName = inferCorrectAppTarballName();
+            deployTarballResource(tarballResourceUrl, targetName);
+        }
+        
+    }
+
+    private void initDeployAppAttributeIfIsNull() {
+        if (getDeployedApps() == null)
+            setDeployedApps(Sets.<String>newLinkedHashSet());
+    }
+
+    private String inferCorrectAppGitName() {
+        String result;
+        if (Strings.isEmpty(getConfig(APP_NAME))) {
+            result = SourceNameResolver.getNameOfRepositoryGitFromHttpsUrl(getConfig(GIT_URL));
+        } else {
+            result = getConfig(APP_NAME);
+        }
+        return result;
+    }
+
+    private String inferCorrectAppTarballName() {
+        String result;
+        if (Strings.isEmpty(getConfig(APP_NAME))) {
+            result = SourceNameResolver.getIdOfTarballFromUrl(getConfig(TARBALL_URL));
+        } else {
+            result = getConfig(APP_NAME);
+        }
+        return result;
+    }
+
+    public void deployGitResource(String url, String targetName) {
+        try {
+            doDeployGitResource(url, targetName);
+        } catch (RuntimeException e) {
+            LOG.error("Error deploying '" + url + "' on " + toString() + "; rethrowing...", e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private void doDeployGitResource(String url, String targetName) {
+        checkNotNull(url, "url");
+        PhpWebAppDriver driver = getDriver();
+        String deployedAppName = driver.deployGitResource(url, targetName);
+        updateDeploymentSensorToDeployAnApp(deployedAppName);
+    }
+
+    public void deployTarballResource(String url, String targetName) {
+        try {
+            doDeployTarballResource(url, targetName);
+        } catch (RuntimeException e) {
+            LOG.error("Error deploying '" + url + "' on " + toString() + "; rethrowing...", e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private void doDeployTarballResource(String url, String targetName) {
+        //TODO deployment git resource
+        checkNotNull(url, "url");
+        PhpWebAppDriver driver = getDriver();
+        String deployedAppName = driver.deployTarballResource(url, targetName);
+        updateDeploymentSensorToDeployAnApp(deployedAppName);
+    }
+
+    private void updateDeploymentSensorToDeployAnApp(String deployedAppName) {
+        Set<String> deployedPhpApps = getDeployedApps();
+        if (deployedPhpApps == null) {
+            deployedPhpApps = Sets.newLinkedHashSet();
+        }
+        deployedPhpApps.add(deployedAppName);
+        setDeployedApps(deployedPhpApps);
+    }
+    
+    public void undeploy(String targetName) {
+        try {
+            doUndeploy(targetName);
+        } catch (RuntimeException e) {
+            LOG.error("Error undeploying '" + targetName + "' on " + toString() + "; rethrowing...", e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private void doUndeploy(String targetName) {
+        PhpWebAppDriver driver = getDriver();
+        driver.undeploy(targetName);
+        
+        // Updating deploy sensor
+        initDeployAppAttributeIfIsNull();
+        Set<String> deployedPhpApps = getDeployedApps();
+        deployedPhpApps.remove(targetName);
+        setDeployedApps(deployedPhpApps);
+    }
+
+
+    
+}

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppSshDriver.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/PhpWebAppSshDriver.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.php;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.entity.SourceNameResolver;
+import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
+import org.apache.brooklyn.entity.webapp.HttpsSslConfig;
+import org.apache.brooklyn.entity.webapp.WebAppService;
+import org.apache.brooklyn.entity.webapp.WebAppServiceConstants;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.text.Strings;
+
+
+public abstract class PhpWebAppSshDriver extends AbstractSoftwareProcessSshDriver implements PhpWebAppDriver {
+
+    public PhpWebAppSshDriver(PhpWebAppSoftwareProcessImpl entity, SshMachineLocation machine) {
+        super(entity, machine);
+    }
+
+    @Override
+    public PhpWebAppSoftwareProcessImpl getEntity() {
+        return (PhpWebAppSoftwareProcessImpl) super.getEntity();
+    }
+
+    protected boolean isProtocolEnabled(String protocol) {
+        Set<String> protocols = getEnabledProtocols();
+        for (String contender : protocols) {
+            if (protocol.equalsIgnoreCase(contender)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Set<String> getEnabledProtocols() {
+        return entity.getAttribute(PhpWebAppSoftwareProcess.ENABLED_PROTOCOLS);
+    }
+
+    @Override
+    public Integer getHttpPort() {
+        return entity.getAttribute(Attributes.HTTP_PORT);
+    }
+
+    @Override
+    public Integer getHttpsPort() {
+        return entity.getAttribute(Attributes.HTTPS_PORT);
+    }
+
+    @Override
+    public HttpsSslConfig getHttpsSslConfig() {
+        return entity.getAttribute(WebAppServiceConstants.HTTPS_SSL_CONFIG);
+    }
+
+    protected Map<String, Integer> getPortMap() {
+        return ImmutableMap.of("httpPort", entity.getAttribute(WebAppService.HTTP_PORT));
+    }
+
+    @Override
+    public Set<Integer> getPortsUsed() {
+        return ImmutableSet.<Integer>builder()
+                .addAll(super.getPortsUsed())
+                .addAll(getPortMap().values())
+                .build();
+    }
+
+    //TODO refactor this method (abstract super class)
+    protected String inferRootUrl() {
+        if (isProtocolEnabled("https")) {
+            Integer port = getHttpsPort();
+            checkNotNull(port, "HTTPS_PORT sensors not set; is an acceptable port available?");
+            return String.format("https://%s:%s/", getHostname(), port);
+        } else if (isProtocolEnabled("http")) {
+            Integer port = getHttpPort();
+            checkNotNull(port, "HTTP_PORT sensors not set; is an acceptable port available?");
+            return String.format("http://%s:%s/", getHostname(), port);
+        } else {
+            throw new IllegalStateException("HTTP and HTTPS protocols not enabled for " + entity + "; enabled protocols are " + getEnabledProtocols());
+        }
+    }
+
+    @Override
+    public void postLaunch() {
+        String rootUrl = inferRootUrl();
+        entity.setAttribute(Attributes.MAIN_URI, URI.create(rootUrl));
+        entity.setAttribute(WebAppService.ROOT_URL, rootUrl);
+    }
+
+    protected abstract String getDeploySubdir();
+
+    protected String getDeployDir() {
+        if (getDeploySubdir() == null)
+            throw new IllegalStateException("no deployment directory available for " + this);
+        //getRunDir is configured in SoftwareProcess
+        return getRunDir() + "/" + getDeploySubdir();
+    }
+
+    @Override
+    public String deployGitResource(String url, String targetName) {
+        log.info("{} deploying Git Resource {} to {}:{}", new Object[]{entity, url, getHostname()});
+        String deployTargetDir = getDeployDir() + targetName;
+        int copyResult = copyUsingProtocol(url, deployTargetDir);
+        if (copyResult != 0)
+            log.warn("Problem deploying {} to {}:{} for {}: result {}", new Object[]{url, getHostname(), deployTargetDir, entity, copyResult});
+        return targetName;
+    }
+
+    public String deployTarballResource(String url, String targetName) {
+        String deployTargetDir = getDeployDir() + "/";
+        String tarballResourceName = SourceNameResolver.getTarballResourceNameFromUrl(url);
+        
+        log.info("{} deploying Tarball Resource {} to {}:{}", entity, url, getHostname(), deployTargetDir);
+
+        //Fixme using copyResource. The proxy it is the problem.
+        int copyResult = copyResourceFromUrl(url, deployTargetDir, true);
+
+        if (copyResult != 0)
+            log.error("Problem deploying {} to {}:{} for {}: result {}", url, getHostname(), deployTargetDir, entity, copyResult);
+
+        int extractResult = extractTarballResource(deployTargetDir, tarballResourceName);
+
+        if (extractResult != 0)
+            log.error("Problem extracting {} in {} result {} for {}", tarballResourceName, deployTargetDir, extractResult, entity);
+
+        return targetName;
+    }
+
+    private int copyResourceFromUrl(String url, String deployTargetDir, boolean createParent) {
+        if (createParent)
+            createParentDir(deployTargetDir);
+        String downloadCommand = String.format("sudo wget -P %s %s", deployTargetDir, url);
+        return getMachine().execCommands("download resource", ImmutableList.of(downloadCommand));
+    }
+
+    private void createParentDir(String dir) {
+        int lastSlashIndex = dir.lastIndexOf("/");
+        String parent = (lastSlashIndex > 0) ? dir.substring(0, lastSlashIndex) : null;
+        if (parent != null) {
+            getMachine().execCommands("createParentDir", ImmutableList.of("sudo mkdir -p " + parent));
+        }
+    }
+
+    private int extractTarballResource(String deployTargetDir, String tarballResourceName) {
+        String extractCommand = String.format("sudo tar xzfv %s%s -C %s", deployTargetDir, tarballResourceName, deployTargetDir);
+        return getMachine().execCommands("extract tarball resource", ImmutableList.of(extractCommand));
+    }
+
+    @Override
+    public void install() {
+        //Fixme use the newScript to install php
+
+        int resultOfCommand = getMachine().execCommands("install php", ImmutableList.of("sudo apt-get -y install php5"));
+        if (resultOfCommand != 0) {
+            log.warn("Problem installing php result {}", resultOfCommand);
+        }
+
+        resultOfCommand = getMachine().execCommands("install php-mysql", ImmutableList.of("sudo apt-get -y install php5-mysql"));
+        if (resultOfCommand != 0) {
+            log.warn("Problem installing php-mysql module result {}", resultOfCommand);
+        }
+    }
+
+    @Override
+    public void stop() {
+        newScript(STOPPING).execute();
+    }
+
+    @Override
+    public void undeploy(String targetName) {
+        String dest = getDeployDir() + "/" + targetName;
+        log.info("{} undeploying {}:{}", new Object[]{entity, getHostname(), dest});
+        int result = getMachine().execCommands("removing artifact on undeploy", ImmutableList.of(String.format("sudo rm -f %s", dest)));
+        log.debug("{} undeployed {}:{}: result {}", new Object[]{entity, getHostname(), dest, result});
+    }
+
+    public static final String  GIT_EXTENSION = ".git";
+    public final static String HTTPS_PREFIX="https://";
+
+
+    public int copyUsingProtocol(String url, String deployTargetDir){
+        int result =0;
+        if(isHttpsGitURL(url)){
+            log.info("The URL it is a git repository: {}", new Object[]{url});
+            result = copyUsingProtocolGitHttps(url, deployTargetDir);
+        }
+        return result;
+    }
+
+    private  boolean isHttpsGitURL(String url){
+        boolean isHttpsGitURL;
+        if(Strings.isBlank(url)) {
+            log.info("git URL is null.");
+        }
+        isHttpsGitURL=checkGitExtension(url)&&checkHttpsPrefix(url);
+        return isHttpsGitURL;
+    }
+
+    private  boolean checkGitExtension(String url){
+        boolean hasGitExtension=false;
+        int lastPoint =url.lastIndexOf(".");
+        if(lastPoint!=-1)
+            hasGitExtension=url.substring(lastPoint).toLowerCase().equals(GIT_EXTENSION);
+        return hasGitExtension;
+    }
+
+    private  boolean checkHttpsPrefix(String url){
+        return url.toLowerCase().startsWith(HTTPS_PREFIX);
+    }
+
+    public int copyUsingProtocolGitHttps(String url, String targetDir){
+        checkAndInstallGit();
+        List<String> commands = ImmutableList.<String>builder()
+                .add(String.format("sudo git clone %s %s", url, targetDir))
+                .build();
+        log.info("Copying git repository url: {} to {}", new Object[]{url, targetDir});
+        int result= newScript(CUSTOMIZING)
+                .body.append(commands)
+                .execute();
+        return result;
+    }
+
+    private void checkAndInstallGit(){
+        int gitInstalled= getMachine().execCommands("checkGitVersion", ImmutableList.of("git --version"));
+        log.info("Git is installed {} {} ", new Object[]{gitInstalled==0, this});
+        if (gitInstalled!=0)
+            installGit();
+    }
+
+    //TODO modify this script using new script functionality
+    private int installGit(){
+        int resultOfCommand;
+        log.info("Installing git {}", new Object[]{this});
+        resultOfCommand = getMachine().execCommands("install Git", ImmutableList.of("sudo apt-get -y install git"));
+        if(resultOfCommand!=0)
+            log.warn("Installing problem installing result {}", resultOfCommand);
+        return resultOfCommand;
+    }
+
+
+}
+
+
+

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/httpd/PhpHttpdDriver.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/httpd/PhpHttpdDriver.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 SeaClouds
+ * Contact: dev@seaclouds-project.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.entity.php.httpd;
+
+
+import org.apache.brooklyn.entity.php.PhpWebAppDriver;
+
+public interface PhpHttpdDriver extends PhpWebAppDriver {
+
+
+}

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/httpd/PhpHttpdServer.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/httpd/PhpHttpdServer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 SeaClouds
+ * Contact: dev@seaclouds-project.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.entity.php.httpd;
+
+
+import org.apache.brooklyn.api.catalog.Catalog;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.objs.HasShortName;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.entity.php.PhpWebAppService;
+import org.apache.brooklyn.entity.php.PhpWebAppSoftwareProcess;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+
+@Catalog(name = "Apache2 HTTPD Server", description = "Apache2 HTTPD Project is an open-source HTTP server")
+@ImplementedBy(PhpHttpdServerImpl.class)
+public interface PhpHttpdServer extends PhpWebAppSoftwareProcess, PhpWebAppService, HasShortName {
+
+    @SetFromFlag("version")
+    ConfigKey<String> SUGGESTED_VERSION =
+            ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.4.7");
+    
+    //TODO Review This definition
+    @SetFromFlag("configDir")
+    BasicAttributeSensorAndConfigKey<String> CONFIG_DIR = new BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey(
+            SoftwareProcess.INSTALL_DIR, "/etc/apache2");
+    //TODO Review This definition
+
+    @SetFromFlag("configuration.dir")
+    BasicAttributeSensorAndConfigKey<String> CONFIGURATION_DIR =
+            new BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey("httpd.configuration.dir", "Configuration Dir", "/etc/apache2");
+
+    @SetFromFlag("sites.available.folder")
+    BasicAttributeSensorAndConfigKey<String> SITES_AVAILABLE =
+            new BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey("httpd.configuration.dir.available.sites", "Folder that contains the configuration and pointed to " +
+                    "the deploy and run folders where deploy the apps ", "/sites-available");
+    
+    @SetFromFlag("site.configuration.filename")
+    ConfigKey<String> SITE_CONFIGURATION_FILE =
+            ConfigKeys.newStringConfigKey("site.configuration.filename", "Filename for the site configuration");
+
+    @SetFromFlag("deploy.run.dir")
+    ConfigKey<String> DEPLOY_RUN_DIR =
+            ConfigKeys.newConfigKey("httpd.deploy.run.dir", "Folder to deploy and run the App", "/var/www");
+
+    @SetFromFlag("defaultGroup")
+    public static final ConfigKey<String> DEFAULT_GROUP = ConfigKeys.newStringConfigKey(
+            "httpd.default.group", "Default user group for applications deployed in DEPLOY_RUN_DIR", "www-data");
+    
+    @SetFromFlag("server.status.url")
+    ConfigKey<String> SERVER_STATUS_URL =
+            ConfigKeys.newConfigKey("httpd.monitor.url", "Relative path showing default server status", "server-status?auto");
+
+    @SetFromFlag("monitor.url.isUp")
+    AttributeSensor<Boolean> SERVER_STATUS_IS_UP =
+            Sensors.newBooleanSensor("webapp.monitor.up", "Httpd status service is up and running");
+
+    @SetFromFlag("traffic.kb")
+    AttributeSensor<Long> TOTAL_KBYTE =
+            Sensors.newLongSensor("webapp.total.kb", "Total server traffic in KB");
+
+    @SetFromFlag("cpu.load")
+    AttributeSensor<Double> CPU_LOAD =
+            Sensors.newDoubleSensor("webapp.cpu.load", "CPU load percent");
+    
+    @SetFromFlag("request.perSec")
+    AttributeSensor<Double> REQUEST_PER_SEC =
+            Sensors.newDoubleSensor("webapp.reqs.perSec", "Requests per sec being managed by the server");
+
+    @SetFromFlag("bytes.perSec")
+    AttributeSensor<Double> BYTES_PER_SEC =
+            Sensors.newDoubleSensor("webapp.bytes.perSec", "Bytes per second");
+
+    @SetFromFlag("bytes.perReq")
+    AttributeSensor<Double> BYTES_PER_REQ =
+            Sensors.newDoubleSensor("webapp.bytes.per.req", "Bytes per requests");
+
+    @SetFromFlag("busy.workers")
+    AttributeSensor<Integer> BUSY_WORKERS =
+            Sensors.newIntegerSensor("webapp.busy.workers", "Number of busy worker");
+
+
+}

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/httpd/PhpHttpdServerImpl.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/httpd/PhpHttpdServerImpl.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2015 SeaClouds
+ * Contact: dev@seaclouds-project.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.entity.php.httpd;
+
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.sensor.Enricher;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.entity.php.PhpWebAppSoftwareProcessImpl;
+import org.apache.brooklyn.feed.function.FunctionFeed;
+import org.apache.brooklyn.feed.function.FunctionPollConfig;
+import org.apache.brooklyn.feed.http.HttpFeed;
+import org.apache.brooklyn.feed.http.HttpPollConfig;
+import org.apache.brooklyn.feed.http.HttpValueFunctions;
+import org.apache.brooklyn.util.guava.Functionals;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PhpHttpdServerImpl extends PhpWebAppSoftwareProcessImpl implements PhpHttpdServer {
+
+    public static final Logger log = LoggerFactory.getLogger(PhpHttpdServerImpl.class);
+
+    private volatile FunctionFeed functionFeed;
+    private volatile HttpFeed httpFeed;
+    private Enricher serviceUpEnricher;
+
+
+    public PhpHttpdServerImpl() {
+        super();
+    }
+
+    public PhpHttpdServerImpl(Map flags) {
+        this(flags, null);
+    }
+
+    public PhpHttpdServerImpl(Map flags, Entity parent) {
+        super(flags, parent);
+    }
+
+    @Override
+    public Class getDriverInterface() {
+        return PhpHttpdDriver.class;
+    }
+
+    @Override
+    public PhpHttpdDriver getDriver() {
+        return (PhpHttpdDriver) super.getDriver();
+    }
+
+    public String getDefaultGroup() {
+        return getConfig(DEFAULT_GROUP);
+    }
+
+    public void setAppUser(String appName) {
+        setConfig(APP_NAME, appName);
+    }
+
+    public String getInstallDir() {
+        return getConfig(PhpHttpdServer.CONFIG_DIR);
+    }
+
+    public String getConfigurationDir() {
+        return getConfig(CONFIGURATION_DIR);
+    }
+
+    public String getSiteConfigurationFile() {
+        return getConfig(SITE_CONFIGURATION_FILE);
+    }
+
+    public void setSiteConfigurationFile(String siteConfigurationFile) {
+        config().set(SITE_CONFIGURATION_FILE, siteConfigurationFile);
+    }
+
+    public String getDeployRunDir() {
+        return getConfig(DEPLOY_RUN_DIR);
+    }
+
+    public String getSitesAvailableFolder() {
+        return getConfig(SITES_AVAILABLE);
+    }
+
+    public String getConfigTemplate() {
+        return getConfig(CONFIG_FILE_TEMPLATE);
+    }
+    
+    public String getConfigurationFile() {
+        return getConfig(CONFIG_FILE);
+    }
+
+    public Map<String, String> getDbConnectionConfigParams() {
+        return getConfig(PHP_CONFIG_PARAMS);
+    }
+
+    public String getPhpVersion() {
+        return getConfig(SUGGESTED_PHP_VERSION);
+    }
+
+
+    @Override
+    public int getHttpPort() {
+        return getAttribute(PhpHttpdServer.HTTP_PORT);
+    }
+
+
+    private Function<String, String> parseApacheStatus(final String key) {
+        return new Function<String, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable String s) {
+                String result = null;
+                if ((s != null) && (key != null) && (s.contains(key))) {
+                    int i = s.indexOf(key) + key.length() + 1;
+                    int j = s.indexOf("\n", i);
+                    result = s.substring(i, j).trim();
+                }
+                return result;
+            }
+        };
+    }
+
+    private <T> Function<String, T> cast(final Class<T> expected) {
+        return new Function<String, T>() {
+            @Nullable
+            @Override
+            public T apply(@Nullable String s) {
+                if (s == null) {
+                    return (T) null;
+                } else if (expected == long.class || expected == Long.class) {
+                    return (T) (Long) Long.parseLong(s);
+                } else if (expected == int.class || expected == Integer.class) {
+                    return (T) (Integer) Integer.parseInt(s);
+                } else if (expected == double.class || expected == Double.class) {
+                    return (T) (Double) Double.parseDouble(s);
+                } else {
+                    return (T) (String) s;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected void connectSensors() {
+        super.connectSensors();
+        functionFeed = FunctionFeed.builder()
+                .entity(this)
+                .poll(new FunctionPollConfig<Object, Boolean>(SERVICE_UP)
+                        .period(500, TimeUnit.MILLISECONDS)
+                        .callable(new Callable<Boolean>() {
+                            public Boolean call() throws Exception {
+                                return getDriver().isRunning();
+                            }
+                        })
+                        .onException(Functions.constant(Boolean.FALSE)))
+                .build();
+
+        String monitorUri = String.format("http://%s:%s/%s",
+                getAttribute(Attributes.HOSTNAME), getHttpPort(), getConfig(SERVER_STATUS_URL));
+        httpFeed = HttpFeed.builder()
+                .entity(this)
+                .period(200)
+                .baseUri(monitorUri)
+                .poll(new HttpPollConfig<Boolean>(SERVER_STATUS_IS_UP)
+                        .onSuccess(HttpValueFunctions.responseCodeEquals(200))
+                        .onFailureOrException(Functions.constant(false)))
+                .poll(new HttpPollConfig<Integer>(REQUEST_COUNT).onSuccess(
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("Total Accesses"), cast(Integer.class))) )
+                .poll(new HttpPollConfig<Long>(TOTAL_KBYTE).onSuccess(
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("Total kBytes"), cast(Long.class))))
+                .poll(new HttpPollConfig<Double>(CPU_LOAD).onSuccess(
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("CPULoad"), cast(Double.class))))
+                .poll(new HttpPollConfig<Integer>(TOTAL_PROCESSING_TIME).onSuccess(
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("Uptime"), cast(Integer.class))))
+                .poll(new HttpPollConfig<Double>(REQUEST_PER_SEC).onSuccess(
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("ReqPerSec"), cast(Double.class))))
+                .poll(new HttpPollConfig<Double>(BYTES_PER_SEC).onSuccess(
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("BytesPerSec"), cast(Double.class))))
+                .poll(new HttpPollConfig<Double>(BYTES_PER_REQ).onSuccess(
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("BytesPerReq"), cast(Double.class))))
+                .poll(new HttpPollConfig<Integer>(BUSY_WORKERS).onSuccess(
+                        Functionals.chain(HttpValueFunctions.stringContentsFunction(),
+                                parseApacheStatus("BusyWorkers"), cast(Integer.class))))
+                .build();
+    }
+
+    @Override
+    public String getShortName() {
+        return "ApacheWebServerHttpd";
+    }
+}

--- a/deployer/src/main/java/org/apache/brooklyn/entity/php/httpd/PhpHttpdSshDriver.java
+++ b/deployer/src/main/java/org/apache/brooklyn/entity/php/httpd/PhpHttpdSshDriver.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2015 SeaClouds
+ * Contact: dev@seaclouds-project.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.entity.php.httpd;
+
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.brooklyn.entity.php.PhpWebAppSshDriver;
+import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
+import org.apache.brooklyn.entity.software.base.lifecycle.ScriptHelper;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PhpHttpdSshDriver extends PhpWebAppSshDriver implements PhpHttpdDriver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PhpHttpdSshDriver.class);
+
+    public PhpHttpdSshDriver(PhpHttpdServerImpl entity, SshMachineLocation machine) {
+        super(entity, machine);
+    }
+
+    @Override
+    public PhpHttpdServerImpl getEntity() {
+        return (PhpHttpdServerImpl) super.getEntity();
+    }
+
+    @Override
+    protected Map<String, Integer> getPortMap() {
+        return ImmutableMap.of("httpPort", getEntity().getHttpPort());
+    }
+
+    @Override
+    protected String getDeploySubdir() {
+        return "";
+    }
+
+    @Override
+    public Integer getHttpPort() {
+        return getEntity().getHttpPort();
+    }
+
+    @Override
+    public String getRunDir() {
+        return getEntity().getConfig(PhpHttpdServer.DEPLOY_RUN_DIR);
+    }
+
+    
+    @Override
+    public void install() {
+        super.install();
+        if (!isApacheInstalled()) {
+            LOG.info("Apache was not installed in {}, proceeding to install it.", new Object[]{this});
+            /*Maybe, we find a old apache configuration file which have to be removed to install the new
+            * server without errors.*/
+            removeOldConfigFile();
+            installApacheServer();
+        }
+    }
+
+    private boolean isApacheInstalled() {
+        boolean apacheIsInstalled = false;
+        int result = getMachine().execCommands("apacheInstalled", ImmutableList.of("apache2 -v"));
+        if (result == 0)
+            apacheIsInstalled = true;
+        return apacheIsInstalled;
+    }
+
+    private void removeOldConfigFile() {
+        String oldApacheConfigurationFilePath = getEntity().getConfigurationDir() + "/" + "apache2.conf";
+        getMachine().execCommands("deleteOldApacheConfigFile", ImmutableList.of("rm -f" + oldApacheConfigurationFilePath));
+    }
+
+    private int installApacheServer() {
+        int result;
+        LOG.info("Installing Apache Server {}", new Object[]{getEntity()});
+        List<String> commands = ImmutableList.<String>builder().add("sudo apt-get install -y --allow-unauthenticated apache2").build();
+        result = newScript(INSTALLING).body.append(commands).execute();
+        if (result != 0)
+            log.warn("Problem installing {} for {}: result {}", new Object[]{entity, result});
+        else
+            log.info("Installed {} for {} commands {}", new Object[]{result, entity, commands});
+        return result;
+    }
+
+    @Override
+    public void customize() {
+        ScriptHelper customizeScript = newScript(CUSTOMIZING)
+                .body.append(
+                        disableCurrentDeployRunDir(),
+                        removeAllAvailableSites(),
+                        createConfigurationFile(),
+                        enableAvailableDeploymentRunDir(),
+                        enableServerStatusServerModule(),
+                        configureHttpPort(),
+                        apacheService(ServiceCommands.RELOAD),
+                        installPhp(),
+                        apacheService(ServiceCommands.RESTART)
+                ).gatherOutput(true);
+        customizeScript.execute();
+        LOG.debug("Customizing Apache: \n{}", customizeScript.getResultStdout());
+        getEntity().deployInitialApplications();
+    }
+    
+    private String disableCurrentDeployRunDir() {
+        StringBuilder stringBuilder = new StringBuilder();
+        String result = String.format(
+                "for file in %s%s/*.conf\n" +
+                        "do\n" +
+                        "FILENAME=$(basename $file)\n" +
+                        "exec sudo a2dissite $FILENAME | true\n" +
+                        "done\n" +
+                        "\n",
+                getEntity().getConfigurationDir(),
+                getEntity().getSitesAvailableFolder());
+        
+        return result;
+    }
+
+    private String removeAllAvailableSites() {
+        String result = String.format(
+                "sudo rm %s%s/*\n",
+                getEntity().getConfigurationDir(),
+                getEntity().getSitesAvailableFolder());
+        return result;
+    }
+
+    private String addAvailableSitesConfiguration(String targetName) {
+        String result = String.format(
+                "sudo bash -c 'cat <<EOT >> %s%s/%s\n" +
+                        "#" + targetName + "\n" +
+                        "<VirtualHost *:%s>\n" +
+                        "DocumentRoot %s/" + targetName + "/\n" +
+                        "ErrorLog ${APACHE_LOG_DIR} /error-" + targetName + ".log\n" +
+                        "CustomLog ${APACHE_LOG_DIR} /access-" + targetName + ".log combined\n" +
+                        "</VirtualHost>\n" +
+                        "EOT'\n" +
+                        "%s\n",
+                getEntity().getConfigurationDir(),
+                getEntity().getSitesAvailableFolder(),
+                getEntity().getSiteConfigurationFile(),
+                getEntity().getHttpPort(),
+                getEntity().getDeployRunDir(),
+                changePermissionsOfFolder(getEntity().getDeployRunDir() + "/" + targetName));
+        return result;
+    }
+
+    private String createConfigurationFile() {
+        String result = String.format(
+                "%s\n" + "sudo touch %s%s/%s",
+                createFolderDeployRunDir(),
+                getEntity().getConfigurationDir(),
+                getEntity().getSitesAvailableFolder(),
+                resolveConfigName(getEntity().getSiteConfigurationFile()));
+        return result;
+    }
+
+    private String resolveConfigName(String inputName){
+        String result;
+        if (Strings.isEmpty(inputName)){
+            result =  getEntity().getAppName() + ".conf";
+        } else if (!inputName.endsWith(".conf")) {
+            result = inputName + ".conf";
+        } else {
+            result = inputName;
+        }
+        getEntity().setSiteConfigurationFile(result); // Updating the sensor
+        return result;
+    }
+    
+    private String createFolderDeployRunDir() {
+        return "mkdir -p " + getRunDir() + "\n";
+    }
+
+    private String changePermissionsOfFolder(String folder) {
+        return String.format("sudo chown -R %s:%s %s\n", getEntity().getDefaultGroup(), getEntity().getDefaultGroup(), folder);
+    }
+
+    private String enableAvailableDeploymentRunDir() {
+        String result = String.format(
+                "for file in %s%s/*.conf\n" +
+                        "do\n" +
+                        "FILENAME=$(basename $file)\n" +
+                        "exec sudo a2ensite $FILENAME | true\n" +
+                        "done\n" +
+                        "%s\n",
+                getEntity().getConfigurationDir(),
+                getEntity().getSitesAvailableFolder(),
+                apacheService(ServiceCommands.RELOAD));
+        return result;
+    }
+
+    private String enableServerStatusServerModule() {
+        String result;
+        result = String.format(
+                "sudo bash -c 'cat <<EOT >> %s/apache2.conf\n" +
+                        "ExtendedStatus On\n" +
+                        "<Location /server-status>\n" +
+                        "SetHandler server-status\n" +
+                        "Require all granted\n" +
+                        "</Location>\n" +
+                        "EOT'\n",
+                getEntity().getConfigurationDir());
+        return result;
+    }
+
+    //TODO the port configuration could be modified. So it is needed find Listen and change the port
+    private String configureHttpPort() {
+        String result;
+        result = String.format(
+                "sudo sed -i 's@Listen[ 0-9]\\+@Listen %s@g' %s/ports.conf",
+                getEntity().getHttpPort(),
+                getEntity().getConfigurationDir()
+        );
+        return result;
+    }
+
+    //TODO refactos using the strategy pattern
+    private String installPhp() {
+        log.debug("Installing PHP v", new Object[]{getEntity().getPhpVersion()});
+        if(getEntity().getPhpVersion().equals("5.4")){
+            return instalPhp54v();
+        }
+        else {
+            return installPhpSuggestedVersionByDefault();
+        }
+    }
+
+    private String instalPhp54v() {
+        String result = String.format(
+                "sudo add-apt-repository -y ppa:ondrej/php5-oldstable"+"\n" +
+                        "sudo apt-get update"+"\n"+
+                        "%s",
+                installPhpSuggestedVersionByDefault());
+        return result;
+    }
+
+
+    private String installPhpSuggestedVersionByDefault() {
+        String result = String.format(
+                "sudo apt-get -y install php5" + "\n" +
+                        "sudo apt-get -y install php5-mysql" + "\n");
+        return result;
+    }
+
+    
+    //TODO
+    @Override
+    public void launch() {
+        //Now this method does not return any value but It should run the app using
+        //the startup files passed in the server of the application
+    }
+
+    @Override
+    public String deployGitResource(String url, String targetName) {
+        super.deployGitResource(url, targetName);
+        newScript(CUSTOMIZING)
+                .body.append(
+                    addAvailableSitesConfiguration(targetName),
+                    apacheService(ServiceCommands.RELOAD),
+                    enableAvailableDeploymentRunDir())
+                .execute();
+        postDeploymentConfiguration(getEntity().getDeployRunDir() + "/" + targetName);
+        return targetName;
+    }
+
+    @Override
+    public String deployTarballResource(String url, String targetName) {
+        super.deployTarballResource(url, targetName);
+        newScript(CUSTOMIZING)
+                .body.append(
+                        addAvailableSitesConfiguration(targetName),
+                        apacheService(ServiceCommands.RELOAD),
+                        enableAvailableDeploymentRunDir())
+                .execute();
+        postDeploymentConfiguration(getEntity().getDeployRunDir() + "/" + targetName);
+        return targetName;
+    }
+
+    @Override
+    public boolean isRunning() {
+        boolean isApacheRunning = false;
+        //int resultOfCommand = getMachine().execCommands("apacheIsRunning", ImmutableList.of("service apache2 status"));
+        String command = "sudo service apache2 status";
+        int resultOfCommand = newScript(AbstractSoftwareProcessSshDriver.CHECK_RUNNING)
+                .body.append(command).execute();
+        if (resultOfCommand == 0)
+            isApacheRunning = true;
+        return isApacheRunning;
+    }
+
+    //TODO merge with the stopApacheMethod in any way
+    @Override
+    public void stop() {
+        String command = "sudo service apache2 stop";
+        newScript(STOPPING)
+                .body.append(command).execute();
+    }
+
+    @Override
+    public void kill() {
+        newScript(KILLING).execute();
+    }
+
+    private void postDeploymentConfiguration(String targetNameApplication) {
+        String configFile = targetNameApplication + "/" + getEntity().getConfigurationFile();
+        String configTemplate = targetNameApplication + "/" + getEntity().getConfigTemplate();
+        if (!Strings.isEmpty(configTemplate)){
+            copyTemplateToFile(configTemplate, configFile);
+            processPhpTemplate(configFile);
+        } else if (!Strings.isEmpty(getEntity().getConfigurationFile())) {
+            // If no template specified, we assume the target file to be modified directly
+            processPhpTemplate(configFile);
+        }
+    }
+
+    private void processPhpTemplate(String pathFile) {
+        Map<String, String> databaseParameters = getEntity().getDbConnectionConfigParams();
+        String command;
+        Set<String> configurationParameters;
+        if (databaseParameters != null) {
+            configurationParameters = databaseParameters.keySet();
+            log.debug("Template path {} ", new Object[]{pathFile});
+            log.debug("Using {} parameters ", new Object[]{configurationParameters.size()});
+            for (String configurationParameter : configurationParameters) {
+                command = String.format(
+                        "sudo sed -i.tmp 's/define([ ]*'\\''%s'\\''[ ]*,[ ]*'\\''[^']*'\\''[ ]*);/define('\\''%s'\\'' , '\\''%s'\\'');/g' %s",
+                        configurationParameter, 
+                        configurationParameter, 
+                        escapeString(databaseParameters.get(configurationParameter)), 
+                        pathFile);
+                log.debug("Executing replacing command: " + command);
+                getMachine().execCommands("processingPhpConfigTemplate", ImmutableList.of(command));
+            }
+        }
+    }
+    
+    private void copyTemplateToFile(String from, String to){
+        getMachine().execCommands("copying config template to file", ImmutableList.of("sudo cp " + from + " " + to));
+    }
+
+    private String escapeString(String s) {
+        return s.replace("/", "\\/");
+    }
+    
+    private String apacheService(String command){
+        return "sudo service apache2 " + command;
+    }
+    
+    public static class ServiceCommands{
+        static String START = "start";
+        static String STOP = "stop";
+        static String RELOAD = "reload";
+        static String RESTART = "restart";
+    }
+}

--- a/deployer/src/test/java/eu/seaclouds/apache/PhpHttpdServerIntegrationTest.java
+++ b/deployer/src/test/java/eu/seaclouds/apache/PhpHttpdServerIntegrationTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2015 SeaClouds
+ * Contact: dev@seaclouds-project.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.seaclouds.apache;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.mgmt.LocationManager;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.entity.php.PhpWebAppSoftwareProcess;
+import org.apache.brooklyn.entity.php.httpd.PhpHttpdServer;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.test.Asserts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PhpHttpdServerIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(PhpHttpdServerIntegrationTest.class);
+
+
+    private SshMachineLocation loc;
+    private ManagementContext managementContext;
+    private LocationManager locationManager;
+
+    private TestApplication app;
+    private String gitRepoURLApp="https://github.com/kiuby88/phpHelloWorld.git";
+    private String tarballResourceUrl="https://github.com/kiuby88/phpHelloWorld/archive/1.tar.gz";
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        app = ApplicationBuilder.newManagedApp(TestApplication.class);
+        managementContext = app.getManagementContext();
+        locationManager = managementContext.getLocationManager();
+        loc = locationManager.createLocation(LocationSpec.create(SshMachineLocation.class)
+                .configure("address", "localhost"));
+    }
+
+    @AfterMethod(alwaysRun=true)
+    public void tearDown() throws Exception {
+        log.info("Destroy all {}", new Object[]{this});
+        if (app != null)
+           Entities.destroyAll(app.getManagementContext());
+    }
+
+    @Test(groups = {"Integration"})
+    public void testHttpTarballResource() throws Exception {
+        try {
+            integrationTestHttTarballResource();
+        }
+        catch (Exception e){
+            log.error("Exception caught in testHttpTarballResource {} ", new Object[]{e.fillInStackTrace()});
+            tearDown();
+            throw e;
+        }
+    }
+
+    @Test(groups = {"Integration"})
+    public void testHttpGitResource() throws Exception {
+        try {
+            integrationTestHttGitResource();
+        }
+        catch (Exception e){
+            log.error("Exception caught in testHttpGitResource{} ", new Object[]{e.fillInStackTrace()});
+            tearDown();
+            throw e;
+        }
+    }
+
+    private void integrationTestHttTarballResource() throws Exception{
+        final PhpHttpdServer server = app.createAndManageChild(EntitySpec.create(PhpHttpdServer.class)
+                .configure("tarball.url", tarballResourceUrl)
+                .configure("http.port", "8080")
+                .configure(PhpHttpdServer.ENABLED_PROTOCOLS, ImmutableSet.of("http")));
+
+        app.start(ImmutableList.of(loc));
+
+        String httpUrl = "http://"+server.getAttribute(PhpHttpdServer.HOSTNAME)+":"+server.getAttribute(PhpHttpdServer.HTTP_PORT)+"/";
+        assertEquals(server.getAttribute(PhpHttpdServer.ROOT_URL).toLowerCase(), httpUrl.toLowerCase());
+        assertEquals(server.getAttribute(PhpWebAppSoftwareProcess.DEPLOYED_PHP_APPS).size(), 1);
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertNotNull(server.getAttribute(PhpHttpdServer.TOTAL_KBYTE));
+                assertNotNull(server.getAttribute(PhpHttpdServer.CPU_LOAD));
+                assertNotNull(server.getAttribute(PhpHttpdServer.REQUEST_PER_SEC));
+                assertNotNull(server.getAttribute(PhpHttpdServer.BYTES_PER_SEC));
+                assertNotNull(server.getAttribute(PhpHttpdServer.BYTES_PER_REQ));
+                assertNotNull(server.getAttribute(PhpHttpdServer.BUSY_WORKERS));
+            }
+        });
+    }
+
+
+    private void integrationTestHttGitResource() throws Exception{
+        final PhpHttpdServer server = app.createAndManageChild(EntitySpec.create(PhpHttpdServer.class)
+                .configure("git.url", gitRepoURLApp)
+                .configure("http.port", "8080")
+                .configure(PhpHttpdServer.ENABLED_PROTOCOLS, ImmutableSet.of("http")));
+
+        app.start(ImmutableList.of(loc));
+
+        String httpUrl = "http://"+server.getAttribute(PhpHttpdServer.HOSTNAME)+":"+server.getAttribute(PhpHttpdServer.HTTP_PORT)+"/";
+        assertEquals(server.getAttribute(PhpHttpdServer.ROOT_URL).toLowerCase(), httpUrl.toLowerCase());
+        assertEquals(server.getAttribute(PhpWebAppSoftwareProcess.DEPLOYED_PHP_APPS).size(), 1);
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertNotNull(server.getAttribute(PhpHttpdServer.TOTAL_KBYTE));
+                assertNotNull(server.getAttribute(PhpHttpdServer.CPU_LOAD));
+                assertNotNull(server.getAttribute(PhpHttpdServer.REQUEST_PER_SEC));
+                assertNotNull(server.getAttribute(PhpHttpdServer.BYTES_PER_SEC));
+                assertNotNull(server.getAttribute(PhpHttpdServer.BYTES_PER_REQ));
+                assertNotNull(server.getAttribute(PhpHttpdServer.BUSY_WORKERS));
+            }
+        });
+    }
+
+}

--- a/deployer/src/test/java/eu/seaclouds/apache/PhpYamlTest.java
+++ b/deployer/src/test/java/eu/seaclouds/apache/PhpYamlTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.seaclouds.apache;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.entity.php.PhpWebAppService;
+import org.apache.brooklyn.entity.php.httpd.PhpHttpdServer;
+import org.apache.brooklyn.launcher.camp.SimpleYamlLauncher;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.annotations.Test;
+
+@Test( groups={"Live"} )
+public class PhpYamlTest {
+
+    public static String APP_NAME = "test-app";
+    
+    @Test
+    public void deployWebappWithServicesFromYaml(){
+        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
+        launcher.setShutdownAppsOnExit(true);
+        Application app = launcher.launchAppYaml("php-helloworld.yaml").getApplication();
+
+        final PhpHttpdServer server = (PhpHttpdServer)
+                findEntityChildByDisplayName(app, "PHP-HTTPD Server");
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertNotNull(server);
+
+                assertTrue(server.getAttribute(Startable.SERVICE_UP));
+
+                assertNotNull(server.getAttribute(Attributes.MAIN_URI));
+                assertNotNull(server.getAttribute(PhpWebAppService.ROOT_URL));
+                assertNotNull(server.getAttribute(PhpWebAppService.HTTP_PORT));
+
+                assertNotNull(server.getConfig(PhpWebAppService.APP_NAME));
+                assertEquals(server.getConfig(PhpWebAppService.APP_NAME), APP_NAME);
+            }
+        });
+    }
+
+    private String escapeString(String s) {
+        return s.replace("/", "\\/");
+    }
+
+    private Entity findEntityChildByDisplayName(Application app, String displayName){
+        for(Object entity: app.getChildren().toArray())
+            if(((Entity)entity).getDisplayName().equals(displayName)){
+                return (Entity)entity;
+            }
+        return null;
+    }
+
+    private Object findSensorValueByName(Entity entity, String sensorName){
+        AttributeSensor<Object> sensor = findSensorByName(entity, sensorName);
+        return entity.getAttribute(sensor);
+    }
+
+    @SuppressWarnings("unchecked")
+    private AttributeSensor<Object> findSensorByName(Entity entity, String sensorName){
+        return (AttributeSensor<Object>) entity.getEntityType().getSensor(sensorName);
+    }
+}

--- a/deployer/src/test/resources/php-helloworld.yaml
+++ b/deployer/src/test/resources/php-helloworld.yaml
@@ -1,0 +1,7 @@
+name: PHP HelloWorld
+services:
+- serviceType: org.apache.brooklyn.entity.php.httpd.PhpHttpdServer
+  name: PHP-HTTPD Server
+  location: aws-ec2:us-west-2
+  git.url: https://github.com/kiuby88/phpHelloWorld.git
+  app.name: test-app


### PR DESCRIPTION
Updated support for PHP applications on Brooklyn. This is based on the initial work done by @kiuby88 on the fork of incubator-brooklyn at SeaCloudsEU.

Apache2 is being configurated by default on machines where the apps are deployed. Apps can be deployed either by providing a tarball or a valid git repository. 

