### PR TITLE
SQUASH: squasing last commits for "Optimizer service" task

### DIFF
--- a/planner/optimizer/WebContent/META-INF/MANIFEST.MF
+++ b/planner/optimizer/WebContent/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Class-Path: 
+

--- a/planner/optimizer/WebContent/WEB-INF/faces-config.xml
+++ b/planner/optimizer/WebContent/WEB-INF/faces-config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<faces-config
+    xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd"
+    version="2.0">
+
+</faces-config>

--- a/planner/optimizer/WebContent/WEB-INF/web.xml
+++ b/planner/optimizer/WebContent/WEB-INF/web.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://java.sun.com/xml/ns/javaee"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	version="3.0">
+	<display-name>optimizer</display-name>
+	<description> These are the services of the Optimizer module of SeaClouds project
+</description>
+
+
+
+
+	<servlet>
+		<servlet-name>Jersey REST Service</servlet-name>
+		<servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+		
+		<init-param>
+			<param-name>jersey.config.server.provider.packages</param-name>
+			<param-value>eu.seaclouds.platform.planner.optimizer.resources</param-value>
+		</init-param>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>Jersey REST Service</servlet-name>
+		<url-pattern>/*</url-pattern>
+	</servlet-mapping>
+
+</web-app>

--- a/planner/optimizer/pom.xml
+++ b/planner/optimizer/pom.xml
@@ -18,6 +18,79 @@
 
 	<artifactId>optimizer</artifactId>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<id>maven2-repository.dev.java.net</id>
+			<name>Java.net Repository for Maven</name>
+			<url>http://download.java.net/maven/glassfish/</url>
+		</pluginRepository>
+	</pluginRepositories>
+	<build>
+		<plugins>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>${maven-war-plugin.version}</version>
+				<configuration>
+					<webXml>WebContent/WEB-INF/web.xml</webXml>
+				</configuration>
+			</plugin>
+
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven-failsafe-plugin.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
+				<version>${jetty.version}</version>
+				<configuration>
+					<webAppConfig>
+						<descriptor>WebContent/WEB-INF/web.xml</descriptor>
+					</webAppConfig>
+					<scanIntervalSeconds>10</scanIntervalSeconds>
+					<stopKey>STOP</stopKey>
+					<stopPort>9999</stopPort>
+				</configuration>
+				<executions>
+					<execution>
+						<id>start-jetty</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+							<goal>start</goal>
+
+						</goals>
+						<configuration>
+							<scanIntervalSeconds>0</scanIntervalSeconds>
+						</configuration>
+					</execution>
+					<execution>
+						<id>stop-jetty</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+		</plugins>
+
+
+	</build>
 	<dependencies>
 		<dependency>
 			<groupId>eu.seaclouds-project</groupId>
@@ -35,10 +108,53 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.12</version>
+		</dependency>
+		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-web-api</artifactId>
+			<version>6.0</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.ws.rs</groupId>
+			<artifactId>javax.ws.rs-api</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+
+
+
+		<dependency>
+			<groupId>commons-httpclient</groupId>
+			<artifactId>commons-httpclient</artifactId>
+
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish.jersey.containers</groupId>
+			<artifactId>jersey-container-servlet</artifactId>
+			<version>2.22.1</version>
+		</dependency>
+
+
+
+
 	</dependencies>
 
+	<packaging>war</packaging>
 </project>

--- a/planner/optimizer/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
+++ b/planner/optimizer/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
@@ -31,13 +31,16 @@ import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethod;
 import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
 import eu.seaclouds.platform.planner.optimizer.nfp.QualityAnalyzer;
 import eu.seaclouds.platform.planner.optimizer.nfp.QualityInformation;
+import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
 import eu.seaclouds.platform.planner.optimizer.util.YAMLmatchmakerToOptimizerParser;
 import eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser;
 
 public class OptimizerInitialDeployment {
 
    private SearchMethod engine;
-   private static Logger log = LoggerFactory.getLogger(OptimizerInitialDeployment.class);
+
+   static Logger log;
+
 
    private static final boolean IS_DEBUG = false;
 
@@ -47,6 +50,9 @@ public class OptimizerInitialDeployment {
    }
 
    public OptimizerInitialDeployment(SearchMethodName name) {
+
+      System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, TOSCAkeywords.LOG_LEVEL);
+      log = LoggerFactory.getLogger(OptimizerInitialDeployment.class);
 
       switch (name) {
       case BLINDSEARCH:

--- a/planner/optimizer/src/main/java/eu/seaclouds/platform/planner/optimizer/resources/OptimizerService.java
+++ b/planner/optimizer/src/main/java/eu/seaclouds/platform/planner/optimizer/resources/OptimizerService.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2014 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package eu.seaclouds.platform.planner.optimizer.resources;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.seaclouds.platform.planner.optimizer.Optimizer;
+import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
+
+@Path("/optimizer")
+public class OptimizerService {
+
+   private static final Logger log = LoggerFactory.getLogger(OptimizerService.class.getName());
+   private String NL = System.getProperty("line.separator");
+   
+   @POST
+   @Path("/optimize")
+   @Produces("application/x-yaml")
+   public Response optimize(@FormParam(value="aam") String appModel, @FormParam(value="offers") String suitableCloudOffer, @FormParam(value="optmethod") String optimizationMethod) {
+       Optimizer optimizer;
+       if(optimizationMethod!=null){
+          optimizer=  new Optimizer(SearchMethodName.valueOf((String)optimizationMethod));
+         }
+         else{
+            optimizer=  new Optimizer();  
+         }
+       String[] outputPlans = new String[]{"Plan generation was not possible"};
+       try {
+       
+          outputPlans = optimizer.optimize(appModel, suitableCloudOffer);
+       }
+       catch (Error E) {
+           log.error("Error optimizing");
+       }
+       String out = "";
+       for (String s : outputPlans) {
+           out = String.valueOf(out) + s + this.NL + this.NL + "---" + this.NL + this.NL;
+       }
+     
+       return Response.status((int)200).entity((Object)out).build();
+   }
+
+   @GET
+   @Path("/heartbeat")
+   @Produces(MediaType.TEXT_PLAIN)
+   public String test() {
+ 
+      return "Optimizer alive";
+ 
+     
+ 
+   }
+   
+   @GET
+   @Produces(MediaType.TEXT_PLAIN)
+   public String check() {
+ 
+      return test();
+ 
+     
+ 
+   }
+   
+}

--- a/planner/optimizer/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLgroupsOptimizerParser.java
+++ b/planner/optimizer/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLgroupsOptimizerParser.java
@@ -18,11 +18,10 @@
 package eu.seaclouds.platform.planner.optimizer.util;
 
 import java.util.ArrayList;
-import java.util.Collection;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/MMoutputTest.java
+++ b/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/MMoutputTest.java
@@ -29,6 +29,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
+
 import eu.seaclouds.platform.planner.optimizer.util.YAMLmatchmakerToOptimizerParser;
 
 public class MMoutputTest {
@@ -37,10 +39,15 @@ public class MMoutputTest {
 
    private static String appModel;
 
-   private static Logger log = LoggerFactory.getLogger(MMoutputTest.class);
+
+   static Logger log;
 
    @BeforeClass
    public void createObjects() {
+
+
+      System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, TOSCAkeywords.LOG_LEVEL);
+      log = LoggerFactory.getLogger(MMoutputTest.class);
 
       log.info("Starting TEST optimizer for the TOSCA syntax of September 2015 regarding MATCHMAKER output");
 

--- a/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCASeptember2015Test.java
+++ b/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCASeptember2015Test.java
@@ -43,11 +43,17 @@ public class OptimizerTOSCASeptember2015Test {
    private static String       appModel;
    private static String       suitableCloudOffer;
 
-   private static Logger log = LoggerFactory.getLogger(OptimizerTOSCASeptember2015Test.class);
+   
+   static Logger               log;
+
 
 
 @BeforeClass
 public void createObjects() {
+
+   System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, TOSCAkeywords.LOG_LEVEL);
+   log                   = LoggerFactory
+         .getLogger(OptimizerTOSCASeptember2015Test.class);
 
    log.info("Starting TEST optimizer for the TOSCA syntax of July 2015");
 

--- a/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCAjuly2015Test.java
+++ b/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCAjuly2015Test.java
@@ -17,6 +17,9 @@
 
 package eu.seaclouds.platform.planner.optimizerTest;
 
+
+import static org.junit.Assert.*;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -50,10 +53,16 @@ public class OptimizerTOSCAjuly2015Test {
 
    private static final int NUM_PLANS_TO_GENERATE = 5;
 
-   private static Logger log = LoggerFactory.getLogger(OptimizerTOSCAjuly2015Test.class);
+   static Logger log;
+
+
 
    @BeforeClass
    public void createObjects() {
+
+      System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, TOSCAkeywords.LOG_LEVEL);
+      log = LoggerFactory.getLogger(OptimizerTOSCAjuly2015Test.class);
+
 
       log.info("Starting TEST optimizer for the TOSCA syntax of July 2015");
 

--- a/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/nfp/QualityAnalyzerTest.java
+++ b/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/nfp/QualityAnalyzerTest.java
@@ -36,14 +36,24 @@ import eu.seaclouds.platform.planner.optimizer.nfp.QualityAnalyzer;
 import eu.seaclouds.platform.planner.optimizer.nfp.QualityInformation;
 import eu.seaclouds.platform.planner.optimizerTest.TestConstants;
 
+import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
+
+import eu.seaclouds.platform.planner.optimizerTest.TestConstants;
+
 public class QualityAnalyzerTest {
 
    private static QualityAnalyzer analyzer;
 
-   private static Logger log = LoggerFactory.getLogger(QualityAnalyzerTest.class);
+
+   static Logger log;
+
 
    @BeforeClass
    public void createObjects() {
+
+      System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, TOSCAkeywords.LOG_LEVEL);
+
+      log = LoggerFactory.getLogger(QualityAnalyzerTest.class);
 
       log.info("Starting TEST quality analyzer");
       analyzer = new QualityAnalyzer();

--- a/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/service/OptimizerServiceTestIT.java
+++ b/planner/optimizer/src/test/java/eu/seaclouds/platform/planner/optimizerTest/service/OptimizerServiceTestIT.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2014 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package eu.seaclouds.platform.planner.optimizerTest.service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
+import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
+import eu.seaclouds.platform.planner.optimizerTest.TestConstants;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.io.IOUtils;
+
+public class OptimizerServiceTestIT {
+
+   private static final String BASE_URL = "http://localhost:8080/optimizer/";
+   private static String appModel;
+   private static String suitableCloudOffer;
+
+   private String NL = System.getProperty("line.separator");
+
+   static Logger log;
+
+   @BeforeClass
+   public void createObjects() {
+
+      System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, TOSCAkeywords.LOG_LEVEL);
+
+      log = LoggerFactory.getLogger(OptimizerServiceTestIT.class);
+
+      log.info("Starting TEST optimizer SERVICE");
+
+      final String dir = System.getProperty("user.dir");
+      log.debug("Trying to open files: current executino dir = " + dir);
+
+      try {
+         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
+      } catch (IOException e) {
+         log.error("File for APPmodel not found");
+         e.printStackTrace();
+      }
+
+      try {
+         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME);
+      } catch (IOException e) {
+         log.error("File for Cloud Offers not found");
+         e.printStackTrace();
+      }
+
+   }
+
+   private static String filenameToString(String path) throws IOException {
+      byte[] encoded = Files.readAllBytes(Paths.get(path));
+      return new String(encoded, StandardCharsets.UTF_8);
+   }
+
+   @Test(enabled = TestConstants.EnabledTest)
+   public void testPresenceSolutionBlind() {
+
+      log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer service STARTED ===");
+
+      String url = BASE_URL + "optimize";
+
+      HttpClient client = new HttpClient();
+      PostMethod method = new PostMethod(url);
+
+      method.addParameter("aam", appModel);
+      method.addParameter("offers", suitableCloudOffer);
+      method.addParameter("optmethod", "BLINDSEARCH");
+
+      executeAndCheck(client, method);
+
+      log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer service FINISEHD ===");
+
+   }
+   
+   @Test(enabled = TestConstants.EnabledTest)
+   public void testPresenceSolutionHill() {
+
+      log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer service STARTED ===");
+
+      String url = BASE_URL + "optimize";
+
+      HttpClient client = new HttpClient();
+      PostMethod method = new PostMethod(url);
+
+      method.addParameter("aam", appModel);
+      method.addParameter("offers", suitableCloudOffer);
+      method.addParameter("optmethod", SearchMethodName.HILLCLIMB.toString());
+      executeAndCheck(client, method);
+
+      log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer service FINISEHD ===");
+
+   }
+   
+   @Test(enabled = TestConstants.EnabledTest)
+   public void testPresenceSolutionAnneal() {
+
+      log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer service STARTED ===");
+
+      String url = BASE_URL + "optimize";
+
+      HttpClient client = new HttpClient();
+      PostMethod method = new PostMethod(url);
+
+      method.addParameter("aam", appModel);
+      method.addParameter("offers", suitableCloudOffer);
+      method.addParameter("optmethod", SearchMethodName.ANNEAL.toString());
+
+      executeAndCheck(client, method);
+
+      log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer service FINISEHD ===");
+
+   }
+   
+
+   private void executeAndCheck(HttpClient client, PostMethod method) {
+      InputStream in = null;
+      int numOutputs = 0;
+      String outputLine;
+      String completeOutput = "";
+      try {
+         int statusCode = client.executeMethod(method);
+
+         if (statusCode != -1) {
+            in = method.getResponseBodyAsStream();
+         }
+         Assert.assertNotNull(in);
+         BufferedReader br = new BufferedReader(new InputStreamReader(in));
+
+         while ((outputLine = br.readLine()) != null) {
+            completeOutput += NL + outputLine;
+
+            if (outputLine.contains("---")) {
+               numOutputs++;
+            }
+         }
+      } catch (Exception e) {
+         e.printStackTrace();
+      }
+
+      Assert.assertTrue(numOutputs == 5,
+            "Optimizer has not generated 5 output ADPs. The complete output is" + completeOutput);
+
+   }
+
+   @Test(enabled = TestConstants.EnabledTest)
+   public void testPresenceHeartbeat() {
+
+      log.info("=== TEST for presence of OPTIMIZER service heartbeat in " + BASE_URL +"===");
+
+      String outputLine;
+      String completeOutput = "";
+
+      try {
+
+         URL url = new URL(BASE_URL + "heartbeat");
+         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+         conn.setRequestMethod("GET");
+
+         Assert.assertTrue(conn.getResponseCode() == 200,
+               "Error requesting heartbeat in " + BASE_URL +". Instead of 200 we have received code " + conn.getResponseCode());
+
+         BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
+
+         while ((outputLine = br.readLine()) != null) {
+            completeOutput += NL + outputLine;
+         }
+
+         conn.disconnect();
+
+      } catch (MalformedURLException e) {
+
+         e.printStackTrace();
+
+      } catch (IOException e) {
+
+         e.printStackTrace();
+
+      }
+
+      Assert.assertTrue(completeOutput.contains("alive"),
+            "Optimizer NOT alive. Response of heartbeat is: " + completeOutput);
+
+      log.info("=== TEST for presence of OPTIMIZER service heartbeat in " + BASE_URL +" FINISHED ===");
+
+   }
+
+   @Test(enabled = false)
+   public void testPresenceHeartbeatSNAPSHOT() {
+
+      String urlstring="http://localhost:8080/optimizer-0.8.0-SNAPSHOT/optimizer/";
+      log.info("=== TEST for presence of OPTIMIZER service heartbeat in "+ urlstring +"===");
+
+      String outputLine;
+      String completeOutput = "";
+
+      try {
+
+         URL url = new URL(urlstring + "heartbeat");
+         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+         conn.setRequestMethod("GET");
+
+         Assert.assertTrue(conn.getResponseCode() == 200,
+               "Error requesting heartbeat in " + urlstring + " . Instead of 200 we have received code " + conn.getResponseCode());
+
+         BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
+
+         while ((outputLine = br.readLine()) != null) {
+            completeOutput += NL + outputLine;
+         }
+
+         conn.disconnect();
+
+      } catch (MalformedURLException e) {
+
+         e.printStackTrace();
+
+      } catch (IOException e) {
+
+         e.printStackTrace();
+
+      }
+
+      Assert.assertTrue(completeOutput.contains("alive"),
+            "Optimizer NOT alive. Response of heartbeat is: " + completeOutput);
+
+      log.info("=== TEST for presence of OPTIMIZER service heartbeatin "+ urlstring +" FINISHED ===");
+
+   }
+   
+   @Test(enabled = false)
+   public void testPresenceHeartbeatDIRECT() {
+
+      String urlstring="http://localhost:8080/optimizer/";
+      log.info("=== TEST for presence of OPTIMIZER service heartbeat in "+ "urlstring "+"===");
+
+      String outputLine;
+      String completeOutput = "";
+
+      try {
+
+         URL url = new URL(urlstring + "heartbeat");
+         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+         conn.setRequestMethod("GET");
+
+         Assert.assertTrue(conn.getResponseCode() == 200,
+               "Error requesting heartbeat in " + urlstring + " . Instead of 200 we have received code " + conn.getResponseCode());
+
+         BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
+
+         while ((outputLine = br.readLine()) != null) {
+            completeOutput += NL + outputLine;
+         }
+
+         conn.disconnect();
+
+      } catch (MalformedURLException e) {
+
+         e.printStackTrace();
+
+      } catch (IOException e) {
+
+         e.printStackTrace();
+
+      }
+
+      Assert.assertTrue(completeOutput.contains("alive"),
+            "Optimizer NOT alive. Response of heartbeat is: " + completeOutput);
+
+      log.info("=== TEST for presence of OPTIMIZER service heartbeatin "+ "urlstring "+" FINISHED ===");
+
+   }
+   
+   
+   private String fromInputStreamToString(InputStream in) {
+      StringWriter writer = new StringWriter();
+      try {
+         IOUtils.copy(in, writer);
+      } catch (IOException e) {
+         log.error("It was not possible to transform the inputStream to a String");
+         e.printStackTrace();
+      }
+      return writer.toString();
+
+   }
+
+   @AfterClass
+   public void testFinishced() {
+      log.info("=============Test optimizer service finished ==========");
+   }
+
+}


### PR DESCRIPTION
This PR exposes the Seaclouds optimizer as a service. 
Optimizer functionality has not changed at all in this period. 
This  PR includes tests of the service running on Jetty. 
Although there are changes in 12 files, significant changes are only in 3 of those files, the ones with the larger quantity of modifications.

In the next PR I'll fill the part of the optimizer in the file .bom for brooklyn for its deployment with the platform. 