### PR TITLE
FIX(Designer): Fixed node tooltip when designing topology

### DIFF
--- a/dashboard/src/main/resources/webapp/static/js/editor/canvas.js
+++ b/dashboard/src/main/resources/webapp/static/js/editor/canvas.js
@@ -1,14 +1,14 @@
 /**
  * This is a proof of concept of topology editor using Graph.Node objects.
- * 
+ *
  * Nodes and links can be added to the canvas.
  * Nodes can be moved. Nodes can be linked with other nodes.
- * The action to trigger when dragging a node (move or link) depends on 
+ * The action to trigger when dragging a node (move or link) depends on
  * an init parameter, and can be modified while pressing a mod key (shift, ctrl)
- * 
- * To initialize the canvas: Canvas.init(id, parameters). See below for a 
+ *
+ * To initialize the canvas: Canvas.init(id, parameters). See below for a
  * description of parameters.
- * 
+ *
  * Example:
  *    c = Canvas()
  *    canvas.init("canvas", {
@@ -23,9 +23,9 @@
  *           console.log("model has changed");
  *       }
  *   });
- * 
+ *
  * To update the canvas when nodes are added/modified/removed: Canvas.restart()
- * 
+ *
  * Graph.Node is augmented. See functions's implementation for more details:
  * - decorate() : used to generate a different decoration for each
  *   node type (for example, add an image). By default, it appends a text
@@ -33,11 +33,11 @@
  * - popovertitle(): used to generate the title of the popover when clicking
  *   on a node. By default, it returns the node name.
  * - popovercontent(): used to generate the content of the popover when
- *   clicking on a node. By default, it returns a list containing type and 
- *   index. 
- * 
+ *   clicking on a node. By default, it returns a list containing type and
+ *   index.
+ *
  * A lot of ideas (and how to achieve some things) taken from :
- * 
+ *
  * - http://bl.ocks.org/rkirsling/5001347
  * - http://bl.ocks.org/cjrd/6863459
  *
@@ -45,24 +45,30 @@
  *   j_ : jquery selections
  *   d3_ : d3 selections
  *   g_ : Graph.* nodes (or children)
- * 
+ *
  * @author roman.sosa@atos.net
  */
 
 /*
  * A click gesture generates mousedown, mouseup and click events, in that order.
- * Preventing the mousedown event from propagating is not sufficient to prevent 
- * the click event from propagating too. This must be done in a click event 
+ * Preventing the mousedown event from propagating is not sufficient to prevent
+ * the click event from propagating too. This must be done in a click event
  * listener.
  */
 
 "use strict";
 
 Graph.Link.popovertitle = function(i) {
+    if (this.behaviour && this.behaviour.popovertitle) {
+        return this.behaviour.popovertitle.call(this, i);
+    }
     return "";
 };
 
 Graph.Link.popovercontent = function(i) {
+    if (this.behaviour && this.behaviour.popovercontent) {
+        return this.behaviour.popovercontent.call(this, i);
+    }
     return "";
 };
 
@@ -78,12 +84,18 @@ Graph.Node.decorate = function(dom_element, i) {
 Graph.Node.update = function(dom_element, i) {};
 
 Graph.Node.popovertitle = function(i) {
+    if (this.behaviour && this.behaviour.popovertitle) {
+        return this.behaviour.popovertitle.call(this, i);
+    }
     return this.name;
 };
 
 Graph.Node.popovercontent = function(i) {
-    var content = 
-        "<dt>Type</dt><dd>" + this.type + "</dd>" + 
+    if (this.behaviour && this.behaviour.popovercontent) {
+        return this.behaviour.popovercontent.call(this, i);
+    }
+    var content =
+        "<dt>Type</dt><dd>" + this.type + "</dd>" +
         "<dt>Index</dt><dd>" + i + "</dd>";
     return "<dl>" + content + "</dl>";
 };
@@ -92,7 +104,7 @@ var Canvas = (function() {
 
     var WIDTH = 960,
         HEIGHT = 500;
-        
+
     var NODE_RADIUS = 20;
 
     /*
@@ -102,15 +114,15 @@ var Canvas = (function() {
         width,              /* canvas width. default: WIDTH */
         height,             /* canvas height. default: HEIGHT */
         linkingenabled,     /* set to false for a RO canvas. def:true */
-        linkbydefault,      /* default mode: T: links; F: drag node. def: F 
+        linkbydefault,      /* default mode: T: links; F: drag node. def: F
                              * Press mod keys to swith mode.*/
         changehandler,      /* Function to call on add, delete or firechange */
         addlinkcallback;    /* callback to control link to add */
-        
+
     /*
      * All these variables are initialized in init()
      */
-    
+
     var self,
         force,              /* d3 layout force */
         div,                /* container div */
@@ -122,15 +134,15 @@ var Canvas = (function() {
         d3_nodes,           /* d3 selection of nodes */
         srcnode,            /* source node when linking */
         linking,            /* true if linking */
-        model,              /* store json model (tojson) of the canvas */ 
+        model,              /* store json model (tojson) of the canvas */
         drag;               /* d3 drag (used for dragging nodes) */
 
     function init(id, parameters) {
-        
+
         self = this;
-        
+
         var p = parameters || {};
-        
+
         width = p.width || WIDTH;
         height = p.height || HEIGHT;
         linkingenabled = _get(p.linkingenabled, true);
@@ -154,15 +166,15 @@ var Canvas = (function() {
             .attr("height", height)
             .on("mousemove", mousemove)
             .on("click", click);
-        
+
         svg.append("rect")
             .attr("id", "#" + id + "-rect")
             .attr("width", width)
             .attr("height", height);
-        
+
         /*
          * define arrow markers for graph links
-         */ 
+         */
         svg.append('svg:defs').append('svg:marker')
             .attr('id', 'end-arrow')
             .attr('viewBox', '0 -5 10 10')
@@ -183,30 +195,30 @@ var Canvas = (function() {
           .append('svg:path')
             .attr('d', 'M10,-5L0,0L10,5')
             .attr('fill', '#000');
-        
+
         /*
          * line displayed when dragging new nodes
          */
         drag_line = svg.append('svg:path')
             .attr('class', 'link dragline hidden')
             .attr('d', 'M0,0L0,0');
-          
+
         g_nodes = force.nodes();
         links = force.links();
-        
+
         /*
          * Append g to svg to store links
-         */    
+         */
         d3_links = svg.append("svg:g").attr("class", "linkgroup").selectAll(".link");
-        
+
         /*
          * Append g to svg to store nodes
          */
         d3_nodes = svg.append("svg:g").attr("class", "nodegroup").selectAll("g");
-        
+
         srcnode = undefined;
         linking = 0;
-        
+
         drag = force.drag()
             .origin(function(d){
                 return {x: d.x, y: d.y};
@@ -237,34 +249,34 @@ var Canvas = (function() {
         if(!linking) {
             return;
         }
-    
+
         var mousex = d3.mouse(this)[0],
             mousey = d3.mouse(this)[1];
-            
+
         // update drag line
         drag_line.classed('hidden', false);
         drag_line.attr(
-            'd', 
+            'd',
             'M' + srcnode.x + ',' + srcnode.y + 'L' + mousex + ',' + mousey
         );
     }
-    
-    
+
+
     function mousedown(d3node, d) {
-    
+
         log.debug("mousedown " + "d3node="+d3node.label + " d=" + d);
         if (d3.event.shiftKey) {
             return;
         }
     }
-    
-    
+
+
     function mouseup(d3node, d) {
         /*
          * if linking, d3node is dest node, else src node.
          */
         log.debug("mouseup " + "d3node="+d3node.label + " d=" + d);
-        
+
         if (linking && d3node !== srcnode) {
             var targetnode = d3node;
             var link = Object.create(Graph.Link).setup(srcnode, targetnode);
@@ -281,24 +293,24 @@ var Canvas = (function() {
             restart();
         }
     }
-    
-    
+
+
     function dragclick() {
         log.debug("dragclick");
     }
-    
-    
+
+
     function click() {
         log.debug("click");
     }
-    
-    
+
+
     function dragstart(selected) {
         var e = d3.event.sourceEvent;
         var modpressed = (e.shiftKey || e.ctrlKey);
-        linking = linkingenabled && 
+        linking = linkingenabled &&
             ((linkbydefault && !modpressed) || (!linkbydefault && modpressed));
-            
+
         var mousex = d3.mouse(this)[0],
             mousey = d3.mouse(this)[1];
 
@@ -307,7 +319,7 @@ var Canvas = (function() {
             log.debug('linkstart - srcnode = ' + selected.label);
             return;
         }
-    
+
         log.debug("dragstart");
         selected.fixed = true;
         g_nodes.forEach(function(node) {
@@ -316,10 +328,10 @@ var Canvas = (function() {
             }
         });
     }
-    
-    
+
+
     function dragmove(selected) {
-        
+
         if (!linking) {
             log.debug("dragmove " + selected.label);
             selected.px += d3.event.dx;
@@ -327,12 +339,12 @@ var Canvas = (function() {
             restart();
         }
     }
-    
-    
+
+
     function dragend(selected) {
-    
+
         var e = d3.event.sourceEvent;
-        
+
         if(linking) {
             log.debug("dragend - linking");
             srcnode = undefined;
@@ -347,18 +359,18 @@ var Canvas = (function() {
             log.debug("dragend - moving");
         }
     }
-    
-    
+
+
     function keydown() {
     }
-    
-    
+
+
     function keyup() {
     }
-    
-    
+
+
     function tick() {
-        
+
       d3_links.attr('d', function(d) {
         var deltaX = d.target.x - d.source.x,
             deltaY = d.target.y - d.source.y,
@@ -373,13 +385,13 @@ var Canvas = (function() {
             targetY = d.target.y - (targetPadding * normY);
         return 'M' + sourceX + ',' + sourceY + 'L' + targetX + ',' + targetY;
       });
-        
+
       d3_nodes.attr('transform', function(d) {
         return 'translate(' + d.x + ',' + d.y + ')';
       });
     }
 
-    
+
     function resize(width, height) {
         if (width === undefined) {
             width = div.node().clientWidth;
@@ -396,18 +408,18 @@ var Canvas = (function() {
         return [ width, height ];
     }
 
-    
+
     function restart() {
-        
+
         /*
          * handle links
          */
-        d3_links = d3_links.data(links, function(l) { 
-            return l.source.name + "-" + l.target.name; 
+        d3_links = d3_links.data(links, function(l) {
+            return l.source.name + "-" + l.target.name;
         });
-    
+
         var newlinks = d3_links.enter().append("svg:path");
-        
+
         newlinks
             .attr("class", function(l) { return "link " + (l.type || "");})
             .style("marker-end", "url(#end-arrow)");
@@ -417,11 +429,11 @@ var Canvas = (function() {
                 {
                     'container' : 'body',
                     'placement' : 'auto right',
-                    'title'     : function() { 
-                        return d.popovertitle(links.indexOf(d)); 
+                    'title'     : function() {
+                        return d.popovertitle(links.indexOf(d));
                     },
-                    'content'   : function() { 
-                        return d.popovercontent(links.indexOf(d)); 
+                    'content'   : function() {
+                        return d.popovercontent(links.indexOf(d));
                     },
                     'html'      : true,
                     'trigger'   : 'manual'
@@ -430,12 +442,12 @@ var Canvas = (function() {
         });
         newlinks.on("click", function(d, i) {
             var e = d3.event;
-    
+
             if (e.defaultPrevented) {
                 log.debug("link.click prevented");
                 return; // click suppressed
             }
-    
+
             log.debug("link.click");
             if(e.shiftKey || e.ctrlKey){
             }else{
@@ -443,29 +455,29 @@ var Canvas = (function() {
                 var self = this;
                 $('[data-popover]').each(function (i) {
                     $(this).not(self).popover('hide');
-                });                
+                });
                 $(this).popover("toggle");
             }
             e.stopPropagation();
         });
-            
-    
+
+
         /*
          * remove old links
-         */ 
+         */
         d3_links.exit().remove();
-    
+
         /*
          * handle nodes
-         * 
+         *
          * TODO: Evaluate use second arg = function(d) { return d.name; }
          */
         var selection = svg.select("g.nodegroup").selectAll("g");
         var data = selection.data(g_nodes, function(n) { return n.name; });
         d3_nodes = data;
-        
+
         data.select("text.nodelabel").text(function(d) { return d.label; });
-        
+
         var newnodes = data.enter().append("svg:g");
         newnodes.append("circle")
             .attr("class", "node")
@@ -475,13 +487,13 @@ var Canvas = (function() {
             var g_node = g_nodes[i];
             g_node.decorate(this, i);
         });
-            
+
         newnodes.append("svg:text")
             .attr("x", 0)
             .attr("y", 30)
             .attr("class", "nodelabel")
             .text(function(d) { return d.label; });
-    
+
         newnodes.attr("data-popover", "true").each(function(d, i) {
             $(this).popover(
                 {
@@ -494,15 +506,15 @@ var Canvas = (function() {
                 }
             );
         });
-        
+
         newnodes.on("click", function(d, i) {
             var e = d3.event;
-    
+
             if (e.defaultPrevented) {
                 log.debug("node.click prevented");
                 return; // click suppressed
             }
-    
+
             log.debug("node.click");
             if(e.shiftKey || e.ctrlKey){
             }else{
@@ -510,7 +522,7 @@ var Canvas = (function() {
                 var self = this;
                 $('[data-popover]').each(function (i) {
                     $(this).not(self).popover('hide');
-                });                
+                });
                 $(this).popover('toggle');
             }
             e.stopPropagation();
@@ -524,43 +536,43 @@ var Canvas = (function() {
         .on('mousemove.drag', null);
 
         newnodes.call(force.drag);
-    
+
         d3_nodes.each(function(d, i) {
             var g_node = g_nodes[i];
             g_node.update(this, i);
         });
-        
+
         /*
          * remove old nodes
          */
         data.exit().remove();
-    
+
         force.start();
     }
 
     function getnode(idx) {
         return g_nodes[idx];
     }
-    
-    
+
+
     function getnodebyname(name) {
         return _search(g_nodes, function(node) {
             node.name === name;
         });
     }
-    
-    
+
+
     function getlink(id) {
         return links[id];
     }
-    
-    
+
+
     function getlinkbynodes(source, target) {
         return _search(links, function(link) {
             return link.source === source && link.target === target;
         });
     }
-    
+
     function addnode(node) {
         log.info("Adding node " + node.toString());
         g_nodes.push(node);
@@ -569,39 +581,39 @@ var Canvas = (function() {
 
     function addlink(link) {
         log.info("Adding link " + link.toString());
-        
+
         if (link) {
             links.push(link);
             firechange();
         }
     }
-     
+
     function linknodes(source, target, type) {
-        log.info("Adding link{source=" + source.label + 
+        log.info("Adding link{source=" + source.label +
             " target=" + target.label + "}");
         var newlink = Object.create(Graph.Link).setup(source, target);
         newlink.type = type;
         addlink(newlink);
-        
+
         return newlink;
     }
-    
-    
+
+
     function _search(array, filter) {
         for (var i = 0; i < array.length; i++) {
             var item = array[i];
-            
+
             if (filter(item)) {
                 return item;
             }
         }
     }
-    
-    
+
+
     function _remove(array, filter) {
         for (var i = 0; i < array.length; ) {
             var item = array[i];
-            
+
             if (filter(item)) {
                 array.splice(i, 1);
             }
@@ -610,14 +622,14 @@ var Canvas = (function() {
             }
         }
     }
-    
+
     function removenode(node) {
         log.info("Removing node " + node.label);
 
         _remove(links, function(link) {
             return (link.source === node || link.target === node);
         });
-        
+
         _remove(g_nodes, function(n) {
             return n === node;
         });
@@ -626,7 +638,7 @@ var Canvas = (function() {
     }
 
     function removelink(link) {
-        log.info("Removing link [source=" + link.source.label + 
+        log.info("Removing link [source=" + link.source.label +
                 ", target=" + link.target.label + "]");
         _remove(links, function(l) {
             return l === link;
@@ -634,7 +646,7 @@ var Canvas = (function() {
         firechange();
         restart();
     }
-    
+
     /*
      * Notify externally to the canvas that a node/link has changed
      */
@@ -648,7 +660,7 @@ var Canvas = (function() {
             changehandler(model);
         }
     }
-    
+
     var tojson = function() {
         var result = {
             nodes: [],
@@ -683,21 +695,21 @@ var Canvas = (function() {
             this.addlink(link);
         }
     };
-    
+
     var nodefromjson = function(json, typeMap) {
         var prototype = typeMap[json.type];
         var node = Object.create(prototype);
         node.init( { name: json.name, label: json.label, type: json.type });
         node.properties = json.properties;
-        
+
         return node;
     };
-    
+
     var linkfromjson = function(json, nodeMap) {
         var link = Object.create(Graph.Link);
         var source = nodeMap[json.source];
         var target = nodeMap[json.target];
-        
+
         if (source === undefined) {
             log.error("Node[name=" + json.source + "] not found");
         }
@@ -706,10 +718,10 @@ var Canvas = (function() {
         }
         link.setup(source, target);
         link.properties = json.properties;
-        
+
         return link;
     };
-     
+
     return {
         init: init,
         restart: restart,

--- a/dashboard/src/main/resources/webapp/static/js/editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/js/editor/editor.js
@@ -116,54 +116,61 @@ var Editor = (function() {
      * Override some Link and Node methods regarding Canvas.
      */
 
-    Graph.Link.popovertitle = function(i) {
-        return " " +
-            '<button type="button" class="popover-edit" data-action="edit" data-linkindex="' + i + '">' +
-            '<span aria-hidden="true" class="fa fa-edit"></span></button>' +
-            '<button type="button" class="popover-edit" data-action="delete" data-linkindex="' + i + '">' +
-            '<span aria-hidden="true" class="fa fa-remove"></span></button>';
-    };
+    var LinkBehaviour = {
 
-    Graph.Link.popovercontent = function(i) {
+        popovertitle: function(i) {
+            return " " +
+                '<button type="button" class="popover-edit" data-action="edit" data-linkindex="' + i + '">' +
+                '<span aria-hidden="true" class="fa fa-edit"></span></button>' +
+                '<button type="button" class="popover-edit" data-action="delete" data-linkindex="' + i + '">' +
+                '<span aria-hidden="true" class="fa fa-remove"></span></button>';
+        },
 
-        var content = "";
-        content += item("operations", this.properties.operations);
-        return "<dl>" + content + "</dl>";
-    };
+        popovercontent: function(i) {
 
-    Graph.Node.popovertitle = function(i) {
-        return this.name + "&nbsp;&nbsp;&nbsp;" +
-            '<button type="button" class="popover-edit" data-action="edit" data-nodeindex="' + i + '">' +
-            '<span aria-hidden="true" class="fa fa-edit"></span></button>' +
-            '<button type="button" class="popover-edit" data-action="delete" data-nodeindex="' + i + '">' +
-            '<span aria-hidden="true" class="fa fa-remove"></span></button>';
-    };
-
-    Graph.Node.popovercontent = function(i) {
-        var location = this.location;
-        if (location !== undefined && location !== "") {
-            location = location + " - " + this.location_option;
+            var content = "";
+            content += item("operations", this.properties.calls);
+            return "<dl>" + content + "</dl>";
         }
+    };
 
-        var terms = [
-            [ "Type", this.type],
-            [ "Name", this.name],
-            [ "Category", this.category],
-            [ "Language", this.language],
-            [ "Versions", this.versions],
-            [ "Artifact", this.artifact],
-            [ "Cost", this.cost],
-            [ "Location", location],
-            [ "QoS", this.qos],
-            [ "Infrastructure", this.infrastructure]
-        ];
+    var NodeBehaviour = {
 
-        var content = "";
-        for (var i = 0; i < terms.length; i++) {
-            var term = terms[i];
-            content += item(term[0], term[1]);
+        popovertitle : function (i) {
+             return this.name + "&nbsp;&nbsp;&nbsp;" +
+                 '<button type="button" class="popover-edit" data-action="edit" data-nodeindex="' + i + '">' +
+                 '<span aria-hidden="true" class="fa fa-edit"></span></button>' +
+                 '<button type="button" class="popover-edit" data-action="delete" data-nodeindex="' + i + '">' +
+                 '<span aria-hidden="true" class="fa fa-remove"></span></button>';
+        },
+
+        popovercontent: function(i) {
+            var location = this.location;
+            if (location !== undefined && location !== "") {
+                location = location + " - " + this.location_option;
+            }
+
+            var terms = [
+                [ "Type", this.type],
+                [ "Name", this.name],
+                [ "Category", this.properties.category],
+                [ "Language", this.properties.language],
+                [ "Min version", this.properties.min_version],
+                [ "Max version", this.properties.max_version],
+                [ "Artifact", this.artifact],
+                [ "Cost", this.cost],
+                [ "Location", location],
+                [ "QoS", this.qos],
+                [ "Infrastructure", this.infrastructure]
+            ];
+
+            var content = "";
+            for (var i = 0; i < terms.length; i++) {
+                var term = terms[i];
+                content += item(term[0], term[1]);
+            }
+            return "<dl>" + content + "</dl>";
         }
-        return "<dl>" + content + "</dl>";
     };
 
     function item(key, value) {
@@ -631,7 +638,7 @@ var Editor = (function() {
     }
 
     operationsset.load = function(link) {
-        $("#operations-calls").val(link.properties.calls);
+        $("#operation-calls").val(link.properties.calls);
     };
 
     operationsset.store = function(link) {
@@ -647,11 +654,16 @@ var Editor = (function() {
             typemap[i] =  Types[i];
         }
 
+        for (var i = 0; i < json.nodes.length; i++) {
+            json.nodes[i].behaviour = NodeBehaviour;
+        }
+
+        for (var i = 0; i < json.links.length; i++) {
+            json.links[i].behaviour = LinkBehaviour;
+        }
+
         this.canvas.fromjson(json, typemap);
     };
-
-    function populate_controls() {
-    }
 
     function initialize_fieldssets() {
         commonset.commonset("set-common");
@@ -666,6 +678,7 @@ var Editor = (function() {
     function initialize_forms() {
         webappform.setup(
             Types.WebApplication,
+            NodeBehaviour,
             document.getElementById("add-form"),
             "Web application",
             [commonset, codetechset, nonfunctionalset, infrastructureset],
@@ -673,6 +686,7 @@ var Editor = (function() {
         );
         databaseform.setup(
             Types.Database,
+            NodeBehaviour,
             document.getElementById("add-form"),
             "Database",
             [commonset, databasetechset, nonfunctionalset, infrastructureset],
@@ -680,6 +694,7 @@ var Editor = (function() {
         );
         restform.setup(
             Types.RestService,
+            NodeBehaviour,
             document.getElementById("add-form"),
             "REST service",
             [commonset, codetechset, nonfunctionalset, infrastructureset],
@@ -687,6 +702,7 @@ var Editor = (function() {
         );
         linkform.setup(
             Graph.Link,
+            LinkBehaviour,
             document.getElementById("update-link-form"),
             "Link",
             [operationsset],
@@ -706,5 +722,7 @@ var Editor = (function() {
         init : init,
         addlinkcallback: addlinkcallback,
         fromjson: fromjson,
+        NodeBehaviour: NodeBehaviour,
+        LinkBehaviour: LinkBehaviour,
     };
 })();

--- a/dashboard/src/main/resources/webapp/static/js/editor/forms.js
+++ b/dashboard/src/main/resources/webapp/static/js/editor/forms.js
@@ -45,13 +45,16 @@ var Forms = (function() {
     var Form = {
         /*
          * nodeprototype: prototype of the node that this form creates
+         * behaviour: object with behaviour to delegate Graph.Node and
+         *   Graph.Link functions (popovercontent, popovertitle...)
          * div: DOM modal div containing form
          * title: string to show as header of form
          * fieldsets: array of Fieldset objects that comprise the form
          */
-        setup: function(nodeprototype, div, title, fieldsets) {
+        setup: function(nodeprototype, behaviour, div, title, fieldsets) {
             var self = this;
             this.nodeprototype = nodeprototype;
+            this.behaviour = behaviour;
             this.div = div;
             this.title = title;
             this.fieldsets = fieldsets;
@@ -110,7 +113,8 @@ var Forms = (function() {
             var n = isnewnode?
                 Object.create(this.nodeprototype).init({
                     name: name,
-                    label: label}):
+                    label: label,
+                    behaviour: this.behaviour}):
                 this.node;
             this.ok_impl(n, isnewnode);
         }
@@ -317,7 +321,7 @@ var Forms = (function() {
     };
 
     var populate_select = function($select, options) {
-        var id = $select[0]? $select[0].id : undefined; 
+        var id = $select[0]? $select[0].id : undefined;
         log.debug("populate_select(" + id + ")")
         if ($select.length == 0) {
             log.warn("populate_select " + id + ": empty set");

--- a/dashboard/src/main/resources/webapp/static/js/editor/status.js
+++ b/dashboard/src/main/resources/webapp/static/js/editor/status.js
@@ -1,12 +1,12 @@
 /**
  * This is a proof of concept of topology editor using Graph.Node objects.
- * 
+ *
  *
  * The following prefixes in variables are used:
  *   j_ : jquery selections
  *   d3_ : d3 selections
  *   g_ : Graph.* nodes (or children)
- * 
+ *
  * @author roman.sosa@atos.net
  */
 
@@ -17,48 +17,48 @@ var Status = (function() {
     /*
      * Override some Link and Node methods regarding Canvas.
      */
-    
-    
-    Graph.Link.popovercontent = function(i) {
-        
-        var content = "";
-        content += item("operations", this.properties.operations);
-        return "<dl>" + content + "</dl>";
-    };
-    
-    Graph.Node.popovertitle = function(i) {
-        return this.name;
-    };
-    
-    Graph.Node.popovercontent = function(i) {
-        
-        var terms = [
-            [ "Type", this.type],
-            [ "Status", this.properties.status],
-        ];
-        
-        var content = "";
-        for (var i = 0; i < terms.length; i++) {
-            var key = terms[i][0];
-            var value = terms[i][1];
-            content += "<dt>" + key + "</dt><dd>" + value + "</dd>";
+
+    var LinkBehaviour = {
+        popovercontent : function(i) {
         }
-        return "<dl>" + content + "</dl>";
     };
+
+    var NodeBehaviour = {
+
+        popovertitle: function(i) {
+            return this.name;
+        },
+
+        popovercontent: function(i) {
+
+            var terms = [
+                [ "Type", this.type],
+                [ "Status", this.properties.status],
+            ];
+
+            var content = "";
+            for (var i = 0; i < terms.length; i++) {
+                var key = terms[i][0];
+                var value = terms[i][1];
+                content += "<dt>" + key + "</dt><dd>" + value + "</dd>";
+            }
+            return "<dl>" + content + "</dl>";
+        }
+    };
+
 
     function init(canvas) {
         this.canvas = canvas;
+    }
 
-    }    
-    
-    
+
     function addlinkcallback(canvas, link, accept) {
         /*
-         * check if is a valid link 
+         * check if is a valid link
          */
         if (canvas.getlinkbynodes(link.source, link.target) ||
             canvas.getlinkbynodes(link.target, link.source) ||
-            link.source.type === Types.Database.type || 
+            link.source.type === Types.Database.type ||
             link.target.type === Types.Cloud.type) {
             return undefined;
         }
@@ -70,7 +70,7 @@ var Status = (function() {
             accept();
         });
     }
-    
+
     fromjson = function(json) {
         /*
          * Autogenerate typemap
@@ -79,14 +79,24 @@ var Status = (function() {
         for (var i in Types) {
             typemap[i] =  Types[i];
         }
-        
+
+        for (var i = 0; i < json.nodes.length; i++) {
+            json.nodes[i].behaviour = NodeBehaviour;
+        }
+
+        for (var i = 0; i < json.links.length; i++) {
+            json.links[i].behaviour = LinkBehaviour;
+        }
+
         this.canvas.fromjson(json, typemap);
     };
-    
+
     return {
         init : init,
         addlinkcallback: addlinkcallback,
         fromjson: fromjson,
-        canvas: canvas
+        canvas: canvas,
+        NodeBehaviour: NodeBehaviour,
+        LinkBehaviour: LinkBehaviour,
     };
 })();


### PR DESCRIPTION
When clicking a node or link in the design-topology step, it behaved as on the Status screen. This PR fixes the bug. The code delegates popovertitle and popovercontent functions to a delegate object, instead of overriding the default functions in the hierarchy.

@adriannieto, could you take a look?