### PR TITLE
Simple TOSCA topology for deploying a TomcatServer on aws

### DIFF
--- a/deployer/src/test/resources/tosca-templates/tomcat-hosted.yaml
+++ b/deployer/src/test/resources/tosca-templates/tomcat-hosted.yaml
@@ -1,0 +1,28 @@
+
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+
+imports:
+  - tosca-normative-types:1.0.0.wd03-SNAPSHOT
+  - brooklyn-custom-types:1.0.0-SNAPSHOT
+
+template_name: brooklyn.a4c.simple.tomcat-hosted-compute
+template_version: 1.0.0-SNAPSHOT
+
+description: Sample TOSCA plan, a TomcatServer and a AWS location
+
+topology_template:
+  description: Web Server Sample with Script
+  node_templates:
+    tomcat_server:
+      type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+      properties:
+        wars.root: "http://search.maven.org/remotecontent?filepath=io/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.6.0/brooklyn-example-hello-world-sql-webapp-0.6.0.war"
+        http.port: "8080+"
+
+  # if you want to tell brooklyn to assign a location at deploy time, as part of the template, this is the current way.
+  # it can also be done with camp, referencing this topology template.
+  groups:
+    add_brooklyn_location:
+      members: [ tomcat_server ]
+      policies:
+      - brooklyn.location: aws-ec2:eu-west-1


### PR DESCRIPTION
A first TOSCA topology supported on brooklyn-tosca project.  