### PR TITLE
FEATURE(aamwriter): Language and not handled properties are stored in node template props

### DIFF
--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
@@ -77,13 +77,19 @@ public class Translator {
         NodeTemplate module = new NodeTemplate(dnode.getName());
         topology.addNodeTemplate(module);
         
-        boolean needsContainer = !"".equals(dnode.getContainer());
+        boolean needsContainer = !dnode.getContainer().isEmpty();
+        
+        if (!dnode.getLanguage().isEmpty()) {
+            module.addProperty("language", dnode.getLanguage());
+        }
+        
+        module.addProperties(dnode.getOtherProperties());
         
         /*
          * Handle artifacts
          */
         String artifactValue = dnode.getArtifact();
-        if (!"".equals(artifactValue)) {
+        if (!artifactValue.isEmpty()) {
             String artifactName;
             String artifactType;
             

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/NodeTemplate.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/NodeTemplate.java
@@ -58,6 +58,12 @@ public class NodeTemplate extends LinkedHashMap {
         this.setType(type.getName());
     }
     
+    public void addProperties(Map<String, Object> properties) {
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            properties().put(entry.getKey(), entry.getValue());
+        }
+    }
+    
     public void addProperty(String name, String value) {
         properties().put(name, value);
     }

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DNode.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DNode.java
@@ -18,6 +18,7 @@ package eu.seaclouds.platform.planner.aamwriter.modeldesigner;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.json.simple.JSONObject;
@@ -35,7 +36,7 @@ public class DNode {
     private DGraph graph;
     private String name;
     private String type;
-    private Map<String, String> properties;
+    private Map<String, Object> properties;
     
     private String language;
     private String minVersion;
@@ -48,6 +49,7 @@ public class DNode {
     private String diskSize;
     private String benchmarkResponseTime;
     private String benchmarkPlatform;
+    private List<Map<String, String>> qos;
 
     public DNode(JSONObject jnode, DGraph graph) {
         this.graph = graph;
@@ -55,7 +57,7 @@ public class DNode {
         this.name = (String) jnode.get(Attributes.NAME);
         this.type = (String) jnode.get(Attributes.TYPE);
 
-        this.properties = new HashMap<String, String>();
+        this.properties = new HashMap<String, Object>();
         this.properties.putAll(readProperties(jnode));
     }
 
@@ -65,8 +67,8 @@ public class DNode {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, String> readProperties(JSONObject jnode) {
-        Map<String, String> map =  (Map<String, String>)jnode.get(Attributes.PROPERTIES);
+    private Map<String, Object> readProperties(JSONObject jnode) {
+        Map<String, Object> map =  (Map<String, Object>)jnode.get(Attributes.PROPERTIES);
         
         language = extractStringFromMap("language", map);
         minVersion = extractStringFromMap("min_version", map);
@@ -79,16 +81,22 @@ public class DNode {
         diskSize = extractStringFromMap("disk_size", map);
         benchmarkResponseTime = extractStringFromMap("benchmark_rt", map);
         benchmarkPlatform = extractStringFromMap("benchmark_platform", map);
-        
+        qos = (List) extractListFromMap("qos", map);
         return map;
     }
     
-    private String extractStringFromMap(String key, Map<String, String> map) {
-        String value = map.remove(key);
+    private String extractStringFromMap(String key, Map<String, Object> map) {
+        String value = (String) map.remove(key);
         
         return (value == null)? "" : value;
     }
 
+    private List<Object> extractListFromMap(String key, Map<String, Object> map) {
+        List<Object> value = (List) map.remove(key);
+        
+        return (value == null)? Collections.EMPTY_LIST : value;
+    }
+    
     @Override
     public String toString() {
         return String.format("Node [name=%s, type=%s, properties=%s]", 
@@ -128,23 +136,14 @@ public class DNode {
         return type;
     }
     
-    public Map<String, String> getOtherProperties() {
+    public Map<String, Object> getOtherProperties() {
         return Collections.unmodifiableMap(properties);
     }
     
-//    private String getStringProperty(String key) {
-//        String value = properties.get(key);
-//        return (value == null)? "" : value;
-//    }
-//    
     public String getLanguage() {
         return language;
     }
     
-//    public String getVersion() {
-//        return getStringProperty("version");
-//    }
-
     public String getMinVersion() {
         return minVersion;
     }
@@ -185,4 +184,7 @@ public class DNode {
         return benchmarkPlatform;
     }
     
+    public List<Map<String, String>> getQos() {
+        return qos;
+    }
 }

--- a/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/TranslatorTest.java
+++ b/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/TranslatorTest.java
@@ -49,7 +49,8 @@ public class TranslatorTest {
     private Map<String, Object> t1;
     private Map<String, Object> t2;
     private Map<String, Object> t3;
-
+    private DGraph graph;
+    
     @BeforeMethod
     public void beforeMethod() {
     }
@@ -61,7 +62,7 @@ public class TranslatorTest {
         Yaml yaml = new Yaml(options);
 
         JSONObject root = (JSONObject) TestUtils.loadJson("/3tier.json");
-        DGraph graph = new DGraph(root);
+        graph = new DGraph(root);
 
         Aam aam = new Translator().translate(graph);
         String serializedYaml = yaml.dump(aam);
@@ -139,6 +140,45 @@ public class TranslatorTest {
     public void testConnections() {
         checkConnection(n1, N2);
         checkConnection(n2, N3);
+    }
+    
+    @Test
+    public void testLanguageIsPropertyOfNodeTemplate() {
+        checkProperty(n1, "language", "JAVA");
+        checkProperty(n2, "language", "JAVA");
+    }
+    
+    @Test
+    public void testPassThroughProperties() {
+        checkProperty(n1, "location", graph.getNode("www").getOtherProperties().get("location"));
+        checkProperty(n1, "location_option", graph.getNode("www").getOtherProperties().get("location_option"));
+
+        checkProperty(n2, "location", graph.getNode("webservices").getOtherProperties().get("location"));
+        checkProperty(n2, "location_option", graph.getNode("webservices").getOtherProperties().get("location_option"));
+    }
+    
+    @Test
+    public void testQosIsNotPropertyOfNodeTemplate() {
+        assertNull(getProperty(n1, "qos"));
+        assertNull(getProperty(n2, "qos"));
+        assertNull(getProperty(n3, "qos"));
+    }
+    
+    private Object getProperty(Map<String, Object> nodeTemplate, String propertyName) {
+        Map properties = (Map)nodeTemplate.get("properties");
+        Object actual = properties.get(propertyName);
+        return actual;
+    }
+
+    private void checkLanguage(String expected, Map<String, Object> actualNodeTemplate) {
+        
+        String language = (String) getProperty(actualNodeTemplate, "language");
+        assertEquals(expected, language);
+    }
+    
+    private void checkProperty(Map<String, Object> nodeTemplate, String propertyName, Object expected) {
+        Object actual = getProperty(nodeTemplate, propertyName);
+        assertEquals(expected, actual);
     }
 
     private void checkConnection(Map from, String to) {

--- a/planner/aamwriter/src/test/resources/3tier.json
+++ b/planner/aamwriter/src/test/resources/3tier.json
@@ -22,6 +22,8 @@
                         "threshold": "5000"
                     }
                 ],
+                "location": "DYNAMIC",
+                "location_option": "FOLLOW_SUN",
                 "infrastructure": "platform",
                 "container": "webapp.tomcat.TomcatServer",
                 "benchmark_rt": "200",
@@ -37,7 +39,8 @@
                 "artifact": "",
                 "min_version": "7",
                 "max_version": "8",
-                "location": "",
+                "location": "STATIC",
+                "location_option": "EUROPE",
                 "qos": [],
                 "infrastructure": "compute",
                 "num_cpus": "4",


### PR DESCRIPTION
All the properties defined in a designer node that are explicitly handled in the translation process are stored in the properties of the node template.

There are two exceptions:

* The language of a module is implicitly stored in the node_type, just for the matchmaking process. With this PR, the language is also a property of the node template, so each process that needs to know  the languages of the components, is able to retrieve it (e.g. monitoring rules generator)
* The QoS section of each component are not stored in the node_template properties.
