### PR TITLE
FIX(dashboard): Fixes #167: AAM uses node type equals IAAS or equals PAAS

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
@@ -161,11 +161,11 @@
                                     <input type="radio" id="infrastructure-none" name="infrastructure" value="">Any
                                 </label>
                                 <label class="radio-inline">
-                                    <input type="radio" id="infrastructure-iaas" name="infrastructure" value="IAAS">
+                                    <input type="radio" id="infrastructure-iaas" name="infrastructure" value="compute">
                                     IaaS
                                 </label>
                                 <label class="radio-inline">
-                                    <input type="radio" id="infrastructure-paas" name="infrastructure" value="PAAS">
+                                    <input type="radio" id="infrastructure-paas" name="infrastructure" value="platform">
                                     PaaS
                                 </label>
                             </div>

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -18,8 +18,8 @@ var Editor = (function() {
     var LOCATION_STATIC = "STATIC";
     var LOCATION_DYNAMIC = "DYNAMIC";
 
-    var INFRASTRUCTURE_IAAS = "IAAS";
-    var INFRASTRUCTURE_PAAS = "PAAS";
+    var INFRASTRUCTURE_IAAS = "compute";
+    var INFRASTRUCTURE_PAAS = "platform";
 
     var language_options = {
         "": "",


### PR DESCRIPTION

If the user selects IaaS or PaaS for a module, the matchmaker is not passing any suitable offering to the optimizer. This PR fixes this ( #167 )

@adriannieto : Could you review this?