### PR TITLE
FEATURE(dashboard): Autoscale property in module properties

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
@@ -155,7 +155,7 @@
                             <div class="form-group">
                                 <label for="nf-autoscale">Autoscale component</label>
                                 <select class="form-control" id="nf-autoscale">
-                                    <option value="0">No</option>
+                                    <option value="">No</option>
                                     <option value="1">Yes</option>
                                 </select>
                             </div>

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
@@ -152,6 +152,13 @@
                                 </table>
                                 <!--<input type="text" class="form-control" id="nf-qos" name="nf-qos">-->
                             </div>
+                            <div class="form-group">
+                                <label for="nf-autoscale">Autoscale component</label>
+                                <select class="form-control" id="nf-autoscale">
+                                    <option value="0">No</option>
+                                    <option value="1">Yes</option>
+                                </select>
+                            </div>
                         </fieldset>
                         <fieldset id="set-infrastructure">
                             <legend>Provider Infrastructure <a href="#"><i class="fa fa-chevron-down"> </i></a></legend>

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -499,12 +499,14 @@ var Editor = (function() {
         this.qos_table.load(node.properties.qos);
         $("#nf-benchmark-responsetime").val(node.properties.benchmark_rt);
         $("#nf-benchmark-platform").val(node.properties.benchmark_platform);
+        $("#nf-autoscale").val(node.properties.autoscale);
     };
 
     nonfunctionalset.store = function(node) {
         node.properties.qos = this.qos_table.serialize();
         node.properties.benchmark_rt = $("#nf-benchmark-responsetime").val();
         node.properties.benchmark_platform = $("#nf-benchmark-platform").val();
+        node.properties.autoscale = $("#nf-autoscale").val();
     };
 
 

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -499,14 +499,14 @@ var Editor = (function() {
         this.qos_table.load(node.properties.qos);
         $("#nf-benchmark-responsetime").val(node.properties.benchmark_rt);
         $("#nf-benchmark-platform").val(node.properties.benchmark_platform);
-        $("#nf-autoscale").val(node.properties.autoscale);
+        $("#nf-autoscale").val(node.properties.autoscale? "1" : "");
     };
 
     nonfunctionalset.store = function(node) {
         node.properties.qos = this.qos_table.serialize();
         node.properties.benchmark_rt = $("#nf-benchmark-responsetime").val();
         node.properties.benchmark_platform = $("#nf-benchmark-platform").val();
-        node.properties.autoscale = $("#nf-autoscale").val();
+        node.properties.autoscale = Boolean($("#nf-autoscale").val());
     };
 
 

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/forms.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/forms.js
@@ -59,9 +59,15 @@ var Forms = (function() {
             this.title = title;
             this.fieldsets = fieldsets;
 
+            if (div == undefined) {
+                console.error("Form " + title + ": Div is null ");
+            }
             this.$div = $(div);
             this.$allsets = this.$div.find("fieldset");
             this.form = this.$div.find("form")[0];
+            if (this.form == undefined) {
+                console.error("Form tag not found in " + div.id);
+            }
             this.$title = this.$div.find(".modal-title");
 
             this.node = undefined;

--- a/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/TranslatorTest.java
+++ b/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/TranslatorTest.java
@@ -155,6 +155,9 @@ public class TranslatorTest {
 
         checkProperty(n2, "location", graph.getNode("webservices").getOtherProperties().get("location"));
         checkProperty(n2, "location_option", graph.getNode("webservices").getOtherProperties().get("location_option"));
+
+        checkProperty(n1, "autoscale", graph.getNode("www").getOtherProperties().get("autoscale"));
+        checkProperty(n3, "autoscale", graph.getNode("db1").getOtherProperties().get("autoscale"));
     }
     
     @Test
@@ -163,7 +166,7 @@ public class TranslatorTest {
         assertNull(getProperty(n2, "qos"));
         assertNull(getProperty(n3, "qos"));
     }
-    
+
     private Object getProperty(Map<String, Object> nodeTemplate, String propertyName) {
         Map properties = (Map)nodeTemplate.get("properties");
         Object actual = properties.get(propertyName);

--- a/planner/aamwriter/src/test/resources/3tier.json
+++ b/planner/aamwriter/src/test/resources/3tier.json
@@ -27,7 +27,8 @@
                 "infrastructure": "platform",
                 "container": "webapp.tomcat.TomcatServer",
                 "benchmark_rt": "200",
-                "benchmark_platform": "hp_cloud_services.2xl"
+                "benchmark_platform": "hp_cloud_services.2xl",
+                "autoscale": "1"
             }
         },
         {
@@ -46,7 +47,8 @@
                 "num_cpus": "4",
                 "disk_size": "256",
                 "benchmark_rt": "100",
-                "benchmark_platform": "hp_cloud_services.2xl"
+                "benchmark_platform": "hp_cloud_services.2xl",
+                "autoscale": "0"
             }
         },
         {

--- a/planner/aamwriter/src/test/resources/3tier.json
+++ b/planner/aamwriter/src/test/resources/3tier.json
@@ -28,7 +28,7 @@
                 "container": "webapp.tomcat.TomcatServer",
                 "benchmark_rt": "200",
                 "benchmark_platform": "hp_cloud_services.2xl",
-                "autoscale": "1"
+                "autoscale": true
             }
         },
         {
@@ -48,7 +48,7 @@
                 "disk_size": "256",
                 "benchmark_rt": "100",
                 "benchmark_platform": "hp_cloud_services.2xl",
-                "autoscale": "0"
+                "autoscale": false
             }
         },
         {


### PR DESCRIPTION
Add a property to specify if a module is allowed to be autoscaled or not.

A generated AAM containing this property is:

```
tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
description: atos
imports:
- tosca-normative-types:1.0.0.wd03-SNAPSHOT
topology_template:
  node_templates:
    www:
      type: sc_req.www
      properties:
        autoscale: '1'
      requirements:
      - endpoint: db
    db:
      type: sc_req.db
      properties:
        autoscale: '0'
        mysql_version:
          constraints: []
node_types:
  sc_req.www:
    derived_from: seaclouds.nodes.SoftwareComponent
  sc_req.db:
    derived_from: seaclouds.nodes.database.mysql.MySqlNode
    properties:
      mysql_support:
        constraints:
        - equal: true
      mysql_version:
        constraints: []
groups:
  operation_www:
    members:
    - www
    policies:
    - dependencies:
        operation_db: ''
    - QoSRequirements:
        response_time:
          less_than: 200.0 ms
        availability:
          greater_than: 98.0
        cost:
          less_or_equal: 1000.0 euros_per_month
        workload:
          less_or_equal: 400.0 req_per_min
  operation_db:
    members:
    - db
    policies:
    - dependencies: {}
```

@adriannieto , @perezp : Please, have a look.
