### PR TITLE
FIX: Handle module qos.

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -97,6 +97,12 @@ var Editor = (function() {
         "FOLLOW_KILOWATT": "Follow the kilowatt",
     };
 
+    var qos_metrics = {
+        "AverageResponseTime": "Average Response Time",
+        "AverageThroughput": "Average Throughput",
+        "AppAvailable": "Availability",
+    };
+
     var qos_operators = {
         "": "",
         "less_than": "<",
@@ -145,7 +151,7 @@ var Editor = (function() {
         },
 
         popovercontent: function(i) {
-            var location = this.location;
+            var location = this.properties.location;
             if (location !== undefined && location !== "") {
                 location = location + " - " + this.location_option;
             }
@@ -157,11 +163,11 @@ var Editor = (function() {
                 [ "Language", this.properties.language],
                 [ "Min version", this.properties.min_version],
                 [ "Max version", this.properties.max_version],
-                [ "Artifact", this.artifact],
-                [ "Cost", this.cost],
+                [ "Artifact", this.properties.artifact],
+                [ "Cost", this.properties.cost],
                 [ "Location", location],
-                [ "QoS", this.qos],
-                [ "Infrastructure", this.infrastructure]
+                [ "QoS", this.properties.qos],
+                [ "Infrastructure", this.properties.infrastructure]
             ];
 
             var content = "";
@@ -485,6 +491,7 @@ var Editor = (function() {
 
     nonfunctionalset.nonfunctionalset = function(fieldsetid) {
         this.setup(fieldsetid);
+        Forms.populate_select($("#nf-qos-metric"), qos_metrics);
         Forms.populate_select($("#nf-qos-operator"), qos_operators);
         Forms.populate_select($("#nf-benchmark-platform"), benchmark_platforms);
         /*

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/MonitoringMetrics.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/MonitoringMetrics.java
@@ -1,0 +1,36 @@
+package eu.seaclouds.platform.planner.aamwriter;
+
+public enum MonitoringMetrics {
+
+    APP_AVAILABLE("AppAvailable", ""),
+    AVERAGE_RESPONSE_TIME("AverageResponseTime", "ms"),
+    AVERAGE_THROUGHPUT("AverageThroughput", "req_per_min");
+    
+    private String metricName;
+    private String unit;
+    
+    MonitoringMetrics(String metricName, String unit) {
+        this.metricName = metricName;
+        this.unit = unit;
+    }
+    
+    public String getMetricName() {
+        return metricName;
+    }
+    
+    public String getUnit() {
+        return unit;
+    }
+    
+    public static MonitoringMetrics from(String metricName) {
+        if (metricName == null) {
+            throw new NullPointerException("metricName cannot be null");
+        }
+        for (MonitoringMetrics item : MonitoringMetrics.values()) {
+            if (metricName.equals(item.getMetricName())) {
+                return item;
+            }
+        }
+        throw new IllegalArgumentException("Not found MonitoringMetrics for '" + metricName + "'");
+    }
+}

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/Operation.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/Operation.java
@@ -43,7 +43,11 @@ public class Operation extends LinkedHashMap<String, Object> {
         return name;
     }
     
-    public void addQoSRequirement(Policy.QoSRequirements requirements) {
+    public void addAppQoSRequirement(Policy.AppQoSRequirements requirements) {
+        this.policies().add(requirements);
+    }
+    
+    public void addModuleQoSRequirement(Policy.ModuleQoSRequirements requirements) {
         this.policies().add(requirements);
     }
     

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/Policy.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/Policy.java
@@ -53,18 +53,20 @@ public interface Policy {
         }
     }
 
-    public static class QoSRequirements extends AbstractPolicy<Constraint> {
+    public static class AppQoSRequirements extends AbstractPolicy<Constraint> {
         private static final long serialVersionUID = 1L;
+        
+        private ConstraintBuilder constraintBuilder = new ConstraintBuilder();
     
         public static class Attributes {
-            public static final String NAME = "QoSRequirements";
+            public static final String NAME = "AppQoSRequirements";
             public static final String RESPONSE_TIME = "response_time";
             public static final String AVAILABILITY = "availability";
             public static final String COST = "cost";
             public static final String WORKLOAD = "workload";
         }
         
-        public QoSRequirements(double rt, double availability, double cost, double workload) {
+        public AppQoSRequirements(double rt, double availability, double cost, double workload) {
             super(Attributes.NAME);
             
             getProperties().put(Attributes.RESPONSE_TIME, buildConstraint(Constraint.Names.LT, rt, "ms"));
@@ -74,14 +76,30 @@ public interface Policy {
         }
         
         private Constraint buildConstraint(String operator, double threshold, String unit) {
-            Constraint c;
-            if ("".equals(unit)) {
-                c = new Constraint(operator, threshold);
-            }
-            else {
-                c = new Constraint(operator, threshold + " " + unit);
-            }
-            return c;
+            return constraintBuilder.buildConstraint(operator, threshold, unit);
+        }
+    }
+    
+    public static class ModuleQoSRequirements extends AbstractPolicy<Constraint> {
+        private static final long serialVersionUID = 1L;
+
+        private ConstraintBuilder constraintBuilder = new ConstraintBuilder();
+        
+        public static class Attributes {
+            public static final String NAME = "QoSRequirements";
+        }
+        
+        public ModuleQoSRequirements() {
+            super(Attributes.NAME);
+            
+        }
+        
+        public void addConstraint(String metricName, String operator, double threshold, String unit) {
+            getProperties().put(metricName, buildConstraint(operator, threshold, unit));
+        }
+
+        private Constraint buildConstraint(String operator, double threshold, String unit) {
+            return constraintBuilder.buildConstraint(operator, threshold, unit);
         }
     }
 
@@ -116,4 +134,18 @@ public interface Policy {
         public String getCalls() {
             return calls;
         }
-    } }
+    }
+    
+    static class ConstraintBuilder {
+        private Constraint buildConstraint(String operator, double threshold, String unit) {
+            Constraint c;
+            if ("".equals(unit)) {
+                c = new Constraint(operator, threshold);
+            }
+            else {
+                c = new Constraint(operator, threshold + " " + unit);
+            }
+            return c;
+        }
+    }
+}

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DNode.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DNode.java
@@ -81,7 +81,7 @@ public class DNode {
         diskSize = extractStringFromMap("disk_size", map);
         benchmarkResponseTime = extractStringFromMap("benchmark_rt", map);
         benchmarkPlatform = extractStringFromMap("benchmark_platform", map);
-        qos = (List) extractListFromMap("qos", map);
+        qos = (List) extractQosFromMap("qos", map);
         return map;
     }
     
@@ -95,6 +95,20 @@ public class DNode {
         List<Object> value = (List) map.remove(key);
         
         return (value == null)? Collections.EMPTY_LIST : value;
+    }
+    
+    private List<Map<String, String>> extractQosFromMap(String key, Map<String, Object> map) {
+        List<Map<String, Object>> qos = (List) map.remove(key);
+        
+        if (qos != null) {
+            for (Map<String, Object> listitem : qos) {
+                for (String mapkey : listitem.keySet()) {
+                    Object mapvalue = listitem.get(mapkey);
+                    listitem.put(mapkey, mapvalue.toString());
+                }
+            }
+        }
+        return (qos == null)? Collections.EMPTY_LIST : qos;
     }
     
     @Override

--- a/planner/aamwriter/src/test/resources/3tier.json
+++ b/planner/aamwriter/src/test/resources/3tier.json
@@ -10,18 +10,6 @@
                 "artifact": "",
                 "min_version": "7",
                 "max_version": "8",
-                "qos": [
-                    {
-                        "metric": "throughput",
-                        "operator": "LT",
-                        "threshold": "10"
-                    },
-                    {
-                        "metric": "responsetime",
-                        "operator": "LT",
-                        "threshold": "5000"
-                    }
-                ],
                 "location": "DYNAMIC",
                 "location_option": "FOLLOW_SUN",
                 "infrastructure": "platform",
@@ -42,7 +30,18 @@
                 "max_version": "8",
                 "location": "STATIC",
                 "location_option": "EUROPE",
-                "qos": [],
+                "qos": [
+                    {
+                        "metric": "AverageResponseTime",
+                        "operator": "less_than",
+                        "threshold": "1000"
+                    },
+                    {
+                        "metric": "AppAvailable",
+                        "operator": "greater_than",
+                        "threshold": 99.8
+                    }
+                ],
                 "infrastructure": "compute",
                 "num_cpus": "4",
                 "disk_size": "256",

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
@@ -32,7 +32,7 @@ public class TOSCAkeywords {
    public static final String GROUP_ELEMENT_MEMBERS_TAG       = "members";
 
    
-   public static final String GROUP_POLICY_QOSREQUIREMENTS        = "QoSRequirements";
+   public static final String GROUP_POLICY_QOSREQUIREMENTS        = "AppQoSRequirements";
    public static final String GROUP_POLICY_QOSINFO                 = "QoSInfo";
    public static final String GROUP_ELEMENT_QOS_EXECUTIONTIME      = "execution_time";
    public static final String GROUP_ELEMENT_QOS_BENCHMARK_PLATFORM = "benchmark_platform";


### PR DESCRIPTION
This PR changes:
* designer: the metric name in the designer is now a combobox.
* aamwriter: inserts the qos related to a module in groups/operation_<module>/QoSRequirements. The qos for the application is moved to groups/operation_<frontendmodule>/AppQoSRequirements
* optimizer: gets the application requirements from the new AppQoSRequirements.

@perezp , @szenzaro , @MicheleGuerriero : Please have a look.

This is an example of AAM:
```
tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
description: 3tier example
imports:
- tosca-normative-types:1.0.0.wd03-SNAPSHOT
topology_template:
  node_templates:
    www:
      type: sc_req.www
      properties:
        language: JAVA
        location: DYNAMIC
        location_option: FOLLOW_SUN
        autoscale: true
      requirements:
      - endpoint: webservices
    webservices:
      type: sc_req.webservices
      properties:
        language: JAVA
        location: STATIC
        location_option: EUROPE
        autoscale: false
        java_version:
          constraints:
          - greater_or_equal: '7'
          - less_or_equal: '8'
      requirements:
      - endpoint: db1
    db1:
      type: sc_req.db1
      properties:
        mysql_version:
          constraints:
          - greater_or_equal: '5.0'
          - less_or_equal: '5.6'
node_types:
  sc_req.www:
    derived_from: seaclouds.nodes.webapp.tomcat.TomcatServer
    properties:
      java_support:
        constraints:
        - equal: true
      tomcat_support:
        constraints:
        - equal: true
      java_version:
        constraints:
        - greater_or_equal: '7'
        - less_or_equal: '8'
      resource_type:
        constraints:
        - equal: platform
  sc_req.webservices:
    derived_from: seaclouds.nodes.SoftwareComponent
    properties:
      num_cpus:
        constraints:
        - greater_or_equal: '4'
      disk_size:
        constraints:
        - greater_or_equal: '256'
      resource_type:
        constraints:
        - equal: compute
  sc_req.db1:
    derived_from: seaclouds.nodes.database.mysql.MySqlNode
    properties:
      mysql_support:
        constraints:
        - equal: true
      mysql_version:
        constraints:
        - greater_or_equal: '5.0'
        - less_or_equal: '5.6'
groups:
  operation_www:
    members:
    - www
    policies:
    - QoSInfo:
        execution_time: 200 ms
        benchmark_platform: hp_cloud_services.2xl
    - dependencies:
        operation_webservices: '2'
    - AppQoSRequirements:
        response_time:
          less_than: 2000.0 ms
        availability:
          greater_than: 0.98
        cost:
          less_or_equal: 200.0 euros_per_month
        workload:
          less_or_equal: 50.0 req_per_min
  operation_webservices:
    members:
    - webservices
    policies:
    - QoSInfo:
        execution_time: 100 ms
        benchmark_platform: hp_cloud_services.2xl
    - dependencies:
        operation_db1: '1'
    - QoSRequirements:
        AverageResponseTime:
          less_than: 1000.0 ms
        AppAvailable:
          greater_than: 99.8
  operation_db1:
    members:
    - db1
    policies:
    - dependencies: {}
````
