### PR TITLE
Change types scalable nodes

### DIFF
--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
@@ -204,12 +204,12 @@ public class OptimizerInitialDeployment {
             log.debug("Adding upperWkl= " + upperWklBound + " lowerWkl=" + lowerWklBound + " poolsize=" + maxPoolSize);
             YAMLoptimizerParser.addScalingPolicyToModule(entry.getKey(), baseAppMap, lowerWklBound, upperWklBound, 1,
                   maxPoolSize);
+            YAMLoptimizerParser.changeModuleToScalableType(entry.getKey(), baseAppMap);
          } else {
             log.debug("Module " + entry.getKey() + " was not scalable");
          }
 
       }
-
    }
 
    private String showThresholds(HashMap<String, ArrayList<Double>> thresholds) {

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
@@ -124,9 +124,7 @@ public class OptimizerInitialDeployment {
 
       Map<String, Object>[] appMapSolutions = hashMapOfFoundSolutionsWithThresholds(solutions, appMap, topology,
             appInfoSuitableOptions, numPlansToGenerate, requirements, suitableCloudOffer, hyst);
-      
-      
-      
+
       log.debug("Before ReplaceSuitableServiceByHost and adding the seaclouds.nodes.Compute type information");
 
       String[] stringSolutions = new String[numPlansToGenerate];

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
@@ -124,11 +124,14 @@ public class OptimizerInitialDeployment {
 
       Map<String, Object>[] appMapSolutions = hashMapOfFoundSolutionsWithThresholds(solutions, appMap, topology,
             appInfoSuitableOptions, numPlansToGenerate, requirements, suitableCloudOffer, hyst);
-
-      log.debug("Before ReplaceSuitableServiceByHost");
+      
+      
+      
+      log.debug("Before ReplaceSuitableServiceByHost and adding the seaclouds.nodes.Compute type information");
 
       String[] stringSolutions = new String[numPlansToGenerate];
       for (int i = 0; i < appMapSolutions.length; i++) {
+         YAMLoptimizerParser.addComputeTypeToTypes(appMapSolutions[i]);
          YAMLoptimizerParser.replaceSuitableServiceByHost(appMapSolutions[i]);
          stringSolutions[i] = YAMLoptimizerParser.fromMAPtoYAMLstring(appMapSolutions[i]);
       }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/TopologyElement.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/TopologyElement.java
@@ -25,12 +25,12 @@ public class TopologyElement implements Iterable<TopologyElementCalled> {
 
    private String                      name;
    private List<TopologyElementCalled> dependences;
-   private boolean canScale=true;
-   
+   private boolean                     canScale = true;
+
    // the execution time experienced in a machine of performance=1 .
    // It is calculated as the execution time provided multiplied by the
    // discovered performance of the machine. In seconds
-   private double                      execTimeInPowerlessMachine;
+   private double execTimeInPowerlessMachine;
 
    public TopologyElement(String name) {
       this.name = name;
@@ -42,11 +42,11 @@ public class TopologyElement implements Iterable<TopologyElementCalled> {
       this.execTimeInPowerlessMachine = execTime;
       dependences = new ArrayList<TopologyElementCalled>();
    }
-   
+
    public TopologyElement(String name, double execTime, boolean canScale) {
       this.name = name;
       this.execTimeInPowerlessMachine = execTime;
-      this.canScale=canScale;
+      this.canScale = canScale;
       dependences = new ArrayList<TopologyElementCalled>();
    }
 
@@ -105,13 +105,11 @@ public class TopologyElement implements Iterable<TopologyElementCalled> {
    }
 
    public boolean canScale() {
-      // TODO Auto-generated method stub
-      // TODO If it is agreed that some modules cannot scale out and then is
-      // also defined the language in which we represent such characteristic,
-      // this method should implement the checking of whether a module can
-      // scale. Up to now, it is assumed that all can scale out, so the
-      // structure is created.
       return canScale;
+   }
+
+   public void setCanScale(boolean scalability) {
+      canScale = scalability;
    }
 
    // ITERATOR //Iterates over names of modules

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/ComputeType.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/ComputeType.java
@@ -1,0 +1,39 @@
+package eu.seaclouds.platform.planner.optimizer.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ComputeType {
+
+   static Logger log = LoggerFactory.getLogger(ComputeType.class);
+   
+   public static final Map<String,Object> computeType = createComputeType();
+
+   private static Map<String, Object> createComputeType() {
+      Map<String,Object> hardwareIdMap=new HashMap<String,Object>();
+      hardwareIdMap.put(TOSCAkeywords.TYPE_TAG_IN_TYPES_DESCRIPTION, TOSCAkeywords.TYPE_OF_HARDWARE_ID);
+      hardwareIdMap.put(TOSCAkeywords.TYPE_PROPERTIES_REQUIRED, TOSCAkeywords.IS_HARDWARE_PROPERTY_REQUIRED);
+      
+      Map<String,Object> computePropertiesMap=new HashMap<String,Object>();
+      computePropertiesMap.put(TOSCAkeywords.TYPE_PROPERTIES_HARDWARE_ID, hardwareIdMap);
+      
+      Map<String,Object> computeMap=new HashMap<String,Object>();
+      computeMap.put(TOSCAkeywords.IS_TYPE_DERIVED_TAG, TOSCAkeywords.TOSCA_COMPUTE_TYPE);
+      computeMap.put(TOSCAkeywords.TYPE_DESCRIPTION_TAG, TOSCAkeywords.TYPE_DESCRIPTION_CONTENT);
+      computeMap.put(TOSCAkeywords.TYPE_PROPERTIES, computePropertiesMap);
+      return computeMap;
+      
+   }
+   
+   public static void addComputeToTypes(Map<String,Object> typesMap){
+      log.debug("Adding the Compute Map to types map");
+      typesMap.put(TOSCAkeywords.COMPUTE_TYPE, computeType);
+   }
+   
+   
+   
+}

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/ScalingPolicy.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/ScalingPolicy.java
@@ -10,7 +10,7 @@ public class ScalingPolicy {
       Map<String, Object> autoscaleValues = new HashMap<String,Object>();
       
       autoscaleValues.put(TOSCAkeywords.AUTOSCALE_TYPE, TOSCAkeywords.BROOKLYN_AUTOSCALER_POLICY);
-      autoscaleValues.put(TOSCAkeywords.AUTOSCALE_METRIC, TOSCAkeywords.BOOKLYN_AUTOSCALER_METRIC_ARRIVALRATE_PER_SECOND);
+      autoscaleValues.put(TOSCAkeywords.AUTOSCALE_METRIC, TOSCAkeywords.AGNOSTIC_AUTOSCALER_METRIC_ARRIVALRATE_PER_SECOND);
       autoscaleValues.put(TOSCAkeywords.AUTOSCALE_METRIC_LOWERBOUND, wklLowerBound);
       autoscaleValues.put(TOSCAkeywords.AUTOSCALE_METRIC_UPPERBOUND, wklUpperBound);
       autoscaleValues.put(TOSCAkeywords.AUTOSCALE_POOL_MINIMUM_SIZE, minPoolSize);

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
@@ -35,7 +35,7 @@ public class TOSCAkeywords {
    public static final String MODULE_PROPERTIES_TAG      = "properties";
    public static final String MODULE_AUTOSCALE_PROPERTY               ="autoscale";
    
-   public static final String GROUP_POLICY_QOSREQUIREMENTS        = "QoSRequirements";
+   public static final String GROUP_POLICY_QOSREQUIREMENTS        = "AppQoSRequirements";
    public static final String GROUP_POLICY_QOSINFO                 = "QoSInfo";
    public static final String GROUP_ELEMENT_QOS_EXECUTIONTIME      = "execution_time";
    public static final String GROUP_ELEMENT_QOS_BENCHMARK_PLATFORM = "benchmark_platform";

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
@@ -98,7 +98,19 @@ public class TOSCAkeywords {
    public static final String AUTOSCALE_METRIC_UPPERBOUND                      = "metricUpperBound";
    public static final String AUTOSCALE_POOL_MINIMUM_SIZE                      = "minPoolSize";
    public static final String AUTOSCALE_POOL_MAXIMUM_SIZE                      = "maxPoolSize";
-
+   
+   //This is to define the Compute node type
+   public static final String COMPUTE_TYPE = "seaclouds.nodes.Compute";
+   public static final String TOSCA_COMPUTE_TYPE = "tosca.nodes.Compute";
+   public static final String TYPE_DESCRIPTION_TAG= "description";
+   public static final String TYPE_DESCRIPTION_CONTENT = "Custom compute";
+   public static final String TYPE_PROPERTIES = "properties";
+   public static final String TYPE_PROPERTIES_HARDWARE_ID= "hardwareId";
+   public static final String TYPE_PROPERTIES_REQUIRED = "required";
+   public static final String TYPE_TAG_IN_TYPES_DESCRIPTION = "type";
+   public static final String TYPE_OF_HARDWARE_ID = "string";
+   public static final boolean IS_HARDWARE_PROPERTY_REQUIRED= false;
+   
    public static final String CLOUD_OFFER_PROVIDER_NAME_SEPARATOR = "\\.";
    public static final String LOG_LEVEL                           = "TRACE";
 

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
@@ -21,8 +21,10 @@ public class TOSCAkeywords {
 
    public static final String TOPOLOGY_TEMPLATE               = "topology_template";
    public static final String NODE_TEMPLATE                   = "node_templates";
+   public static final String NODE_TYPES                      = "node_types";
    public static final String SUITABLE_SERVICES               = "suitableServices";
    public static final String MODULE_REQUIREMENTS             = "requirements";
+   public static final String MODULE_TYPE                     = "type";
    public static final String MODULE_REQUIREMENTS_CONSTRAINTS = "constraints";
    public static final String MODULE_REQUIREMENTS_HOST        = "host";
    public static final String CLOUD_OFFER_PROPERTIES_TAG      = "properties";
@@ -31,38 +33,40 @@ public class TOSCAkeywords {
    public static final String GROUP_ELEMENT_TAG               = "groups";
    public static final String GROUP_ELEMENT_MEMBERS_TAG       = "members";
 
-   //AUTOSCALING PROPERTIES
-   public static final String MODULE_PROPERTIES_TAG      = "properties";
-   public static final String MODULE_AUTOSCALE_PROPERTY               ="autoscale";
+   //NODE TYPES PROPERTIES 
+   public static final String IS_TYPE_DERIVED_TAG               = "derived_from";
    
-   public static final String GROUP_POLICY_QOSREQUIREMENTS        = "AppQoSRequirements";
-   public static final String GROUP_POLICY_QOSINFO                 = "QoSInfo";
-   public static final String GROUP_ELEMENT_QOS_EXECUTIONTIME      = "execution_time";
-   public static final String GROUP_ELEMENT_QOS_BENCHMARK_PLATFORM = "benchmark_platform";
-   public static final String GROUP_POLICY_DEPENDENCIES = "dependencies";
+   // AUTOSCALING PROPERTIES
+   public static final String MODULE_PROPERTIES_TAG     = "properties";
+   public static final String MODULE_AUTOSCALE_PROPERTY = "autoscale";
+
+   public static final String GROUP_POLICY_QOSREQUIREMENTS           = "AppQoSRequirements";
+   public static final String GROUP_POLICY_QOSINFO                   = "QoSInfo";
+   public static final String GROUP_ELEMENT_QOS_EXECUTIONTIME        = "execution_time";
+   public static final String GROUP_ELEMENT_QOS_BENCHMARK_PLATFORM   = "benchmark_platform";
+   public static final String GROUP_POLICY_DEPENDENCIES              = "dependencies";
    public static final String GROUP_ELEMENT_DEPENDENCIES_MODULES_TAG = "other_modules";
 
-   public static final String GROUP_POLICY_QOSREQUIREMENTS_RESPONSETIME  = "response_time";
-   public static final String GROUP_POLICY_QOSREQUIREMENTS_AVAILABILITY = "availability";
-   public static final String GROUP_POLICY_QOSREQUIREMENTS_COST_MONTH   = "cost";
-   public static final String GROUP_POLICY_QOSREQUIREMENTS_WORKLOAD_MINUTE  = "workload";
-   
+   public static final String GROUP_POLICY_QOSREQUIREMENTS_RESPONSETIME    = "response_time";
+   public static final String GROUP_POLICY_QOSREQUIREMENTS_AVAILABILITY    = "availability";
+   public static final String GROUP_POLICY_QOSREQUIREMENTS_COST_MONTH      = "cost";
+   public static final String GROUP_POLICY_QOSREQUIREMENTS_WORKLOAD_MINUTE = "workload";
+
    public static final String MODULE_PROPOSED_INSTANCES = "instancesPOC";
 
-   //These are for the MM version of September 2015
+   // These are for the MM version of September 2015
    public static final String CLOUD_CONCRETE_OFFER_AVAILABILITY = "availability";
    public static final String CLOUD_CONCRETE_OFFER_PERFORMANCE  = "performance";
    public static final String CLOUD_CONCRETE_OFFER_COST         = "cost";
    public static final String CLOUD_CONCRETE_OFFER_NUM_CORES    = "num_cpus";
-   
-   // These ones have not been defined yet. I temporarily use this definition. Used by the first working version of Optimizer
+
+   // These ones have not been defined yet. I temporarily use this definition.
+   // Used by the first working version of Optimizer
    public static final String CLOUD_OFFER_PROPERTY_AVAILABILITY = "availabilityPOC";
    public static final String CLOUD_OFFER_PROPERTY_PERFORMANCE  = "performancePOC";
    public static final String CLOUD_OFFER_PROPERTY_COST         = "costPOC";
    public static final String LATENCY_INTER_DATACENTER_MILLIS   = "latencyExternalPOC";
    public static final String LATENCY_INTRA_DATACENTER_MILLIS   = "latencyInternalPOC";
-   
-   
 
    public static final String RECONFIGURATION_WORKLOAD_TAG = "ReconfigurationsPOC";
    public static final String EXPECTED_QUALITY_PROPERTIES  = "ExpectedQualityPOC";
@@ -83,19 +87,19 @@ public class TOSCAkeywords {
    public static final String MODULE_QOS_OPERATIONAL_PROFILE  = "OpProfilePOC";
 
    // These ones are for the autoscaling policies
-   public static final String AUTOSCALING_TAG   = "autoscaling";
-   public static final String AUTOSCALE_TYPE= "type";
-   public static final String BROOKLYN_AUTOSCALER_POLICY= "org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy";
-   public static final String AUTOSCALE_METRIC= "metric";
-   public static final String BOOKLYN_AUTOSCALER_METRIC_ARRIVALRATE_PER_SECOND="$brooklyn:sensor(\"org.apache.brooklyn.entity.webapp.DynamicWebAppCluster\", \"webapp.reqs.perSec.windowed.perNode\")";
-   public static final String AUTOSCALE_METRIC_LOWERBOUND= "metricLowerBound";
-   public static final String AUTOSCALE_METRIC_UPPERBOUND= "metricUpperBound";
-   public static final String AUTOSCALE_POOL_MINIMUM_SIZE= "minPoolSize";
-   public static final String AUTOSCALE_POOL_MAXIMUM_SIZE= "maxPoolSize";
-   
-   
-   public static final String CLOUD_OFFER_PROVIDER_NAME_SEPARATOR = "\\.";
-   public static final String LOG_LEVEL = "TRACE";
+   public static final String AUTOSCALING_TAG                                  = "autoscaling";
+   public static final String AUTOSCALE_TYPE                                   = "type";
+   public static final String BROOKLYN_AUTOSCALER_POLICY                       = "org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy";
+   public static final String NODE_TYPE_AUTOSCALABLE                           = "seaclouds.nodes.ControlledDynamicWebAppCluster";
+   public static final String AUTOSCALE_METRIC                                 = "metric";
+   public static final String BROOKLYN_AUTOSCALER_METRIC_ARRIVALRATE_PER_SECOND = "$brooklyn:sensor(\"org.apache.brooklyn.entity.webapp.DynamicWebAppCluster\", \"webapp.reqs.perSec.windowed.perNode\")";
+   public static final String AGNOSTIC_AUTOSCALER_METRIC_ARRIVALRATE_PER_SECOND = "$brooklyn:sensor(\"seaclouds.nodes.ControlledDynamicWebAppCluster\", \"webapp.reqs.perSec.windowed.perNode\")";
+   public static final String AUTOSCALE_METRIC_LOWERBOUND                      = "metricLowerBound";
+   public static final String AUTOSCALE_METRIC_UPPERBOUND                      = "metricUpperBound";
+   public static final String AUTOSCALE_POOL_MINIMUM_SIZE                      = "minPoolSize";
+   public static final String AUTOSCALE_POOL_MAXIMUM_SIZE                      = "maxPoolSize";
 
+   public static final String CLOUD_OFFER_PROVIDER_NAME_SEPARATOR = "\\.";
+   public static final String LOG_LEVEL                           = "TRACE";
 
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLmodulesOptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLmodulesOptimizerParser.java
@@ -20,6 +20,7 @@ package eu.seaclouds.platform.planner.optimizer.util;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -366,6 +367,63 @@ public class YAMLmodulesOptimizerParser {
          // Returning the default value "true" for seeing policies generated
       }
       return true;
+   }
+
+   
+   /**
+    * @param moduleName
+    * @param modulesMap
+    * @return The type of node_template called moduleName
+    */
+   public static String getModuleTypeFromModulesMap(String moduleName, Map<String, Object> modulesMap) {
+      try {
+         Map<String, Object> moduleInternalInfo = (Map<String, Object>) YAMLmodulesOptimizerParser
+               .getModuleInfoFromModulesMap(modulesMap, moduleName).getValue();
+         if (moduleInternalInfo != null) {
+            return YAMLmodulesOptimizerParser.getModuleTypeFromModuleInfo(moduleInternalInfo);
+         } else {
+            return null;
+         }
+      } catch (Exception E) {
+         // Some part was not found in modules map. Logging the event and
+         // returning null
+         log.debug("It was not found the type of module " + moduleName + " in the AAM");
+      }
+      return null;
+   }
+
+   
+   /**
+    * @param moduleInfo (information of the module, excluding the name of the module)
+    * @return The type declared in the node template passed as parameter
+    */
+   public static String getModuleTypeFromModuleInfo(Map<String, Object> moduleInfo) {
+      if (moduleInfo.containsKey(TOSCAkeywords.MODULE_TYPE)) {
+         return (String) moduleInfo.get(TOSCAkeywords.MODULE_TYPE);
+      } else {
+         return null;
+      }
+   }
+
+   
+   /**
+    * @param modulesMap
+    * @param moduleName
+    * @return the information of the node_template with key moduleName (the key is included)
+    */
+   public static Entry<String, Object> getModuleInfoFromModulesMap(Map<String, Object> modulesMap, String moduleName) {
+      if (modulesMap.containsKey(moduleName)) {
+         for (Map.Entry<String, Object> entry : modulesMap.entrySet()) {
+            if (entry.getKey().equals(moduleName)) {
+               if (log.isDebugEnabled()) {
+                  log.debug("return entry that describes module with name '" + entry.getKey() + "'");
+               }
+               return entry;
+            }
+         }
+      }
+      log.warn("Module description not found. Check correcness of name given as group members and modules name");
+      return null;
    }
 
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
@@ -753,4 +753,9 @@ public class YAMLoptimizerParser {
 
    }
 
+   public static void addComputeTypeToTypes(Map<String, Object> appMap) {
+     YAMLtypesOptimizerParser.addComputeType(YAMLoptimizerParser.getTypesMapFromAppMap(appMap));
+      
+   }
+
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
@@ -42,7 +42,6 @@ import eu.seaclouds.platform.planner.optimizer.nfp.QualityInformation;
 //Version of September 2015
 public class YAMLoptimizerParser {
 
-
    static Logger log = LoggerFactory.getLogger(YAMLoptimizerParser.class);
 
    public static void cleanSuitableOfferForModule(String modulename, Map<String, Object> appMap) {
@@ -136,11 +135,12 @@ public class YAMLoptimizerParser {
       YAMLgroupsOptimizerParser.addQualityOfSolutionToGroup(sol, initialElementName, groups);
 
    }
-   
-   public static void addScalingPolicyToModule(String modulename, Map<String,Object> applicationMapComplete, 
-         double wklLowerBound, double wklUpperBound, int minPoolSize, int maxPoolSize){
+
+   public static void addScalingPolicyToModule(String modulename, Map<String, Object> applicationMapComplete,
+         double wklLowerBound, double wklUpperBound, int minPoolSize, int maxPoolSize) {
       Map<String, Object> groups = YAMLoptimizerParser.getGroupMapFromAppMap(applicationMapComplete);
-      YAMLgroupsOptimizerParser.addScalingPolicyToModuleGroup(groups, modulename, wklLowerBound, wklUpperBound, minPoolSize, maxPoolSize);
+      YAMLgroupsOptimizerParser.addScalingPolicyToModuleGroup(groups, modulename, wklLowerBound, wklUpperBound,
+            minPoolSize, maxPoolSize);
    }
 
    private static double getCloudLatency(String suitableCloudOffers, String latencyKeyword) {
@@ -345,7 +345,6 @@ public class YAMLoptimizerParser {
 
    }
 
-
    public static QualityInformation getQualityRequirements(Map<String, Object> applicationMap) {
 
       Map<String, Object> groupsMap = YAMLoptimizerParser.getGroupMapFromAppMap(applicationMap);
@@ -387,7 +386,6 @@ public class YAMLoptimizerParser {
 
    }
 
- 
    public static double getApplicationWorkload(Map<String, Object> applicationMap) {
 
       // The initial element is such one that has QoSrequirements in the
@@ -431,7 +429,8 @@ public class YAMLoptimizerParser {
       if (log.isDebugEnabled()) {
          log.debug("Reading topology. Next step: replace the module name by the name of the host");
       }
-      // TODO: study these two lines and uncomment them if necessary. It may be required in the future (it was in previous
+      // TODO: study these two lines and uncomment them if necessary. It may be
+      // required in the future (it was in previous
       // versions). Change done in the phase of module testing.
       // replaceModuleNameByHostName(topology, (Map<String, Object>)
       // appMap.get(TOSCAkeywords.NODE_TEMPLATE));
@@ -483,9 +482,8 @@ public class YAMLoptimizerParser {
       double hostPerformance = appInfoSuitableOptions.getCloudCharacteristics(elementName,
             YAMLmodulesOptimizerParser.getMeasuredPerformanceHost(elementName, groups)).getPerformance();
 
-      boolean elementCanScale= YAMLmodulesOptimizerParser.getScalabilityCapabilitiesOfModule(modules, elementName);
-            
-            
+      boolean elementCanScale = YAMLmodulesOptimizerParser.getScalabilityCapabilitiesOfModule(modules, elementName);
+
       newelement.setExecTimeMillis(
             YAMLmodulesOptimizerParser.getMeasuredExecTimeMillis(elementName, groups) * hostPerformance);
 
@@ -536,7 +534,8 @@ public class YAMLoptimizerParser {
    }
 
    /**
-    * @return Default qualityInformation. Used just for testing the full execution. 
+    * @return Default qualityInformation. Used just for testing the full
+    *         execution.
     */
    public static QualityInformation getQualityRequirementsForTesting() {
 
@@ -621,7 +620,7 @@ public class YAMLoptimizerParser {
             // 2) find the module in the topology with this name.
 
             Map<String, Object> modulesMap = YAMLoptimizerParser.getModuleMapFromAppMap(appMap);
-            return YAMLoptimizerParser.getModuleInfoFromModulesMap(modulesMap, moduleName);
+            return YAMLmodulesOptimizerParser.getModuleInfoFromModulesMap(modulesMap, moduleName);
 
          }
       }
@@ -632,7 +631,7 @@ public class YAMLoptimizerParser {
    }
 
    @SuppressWarnings("unchecked")
-   public   static String getInitialElementName(Map<String, Object> appMap) {
+   public static String getInitialElementName(Map<String, Object> appMap) {
       // The initial element is such one that has QoSrequirements in the
       // "groups" part.
 
@@ -662,20 +661,7 @@ public class YAMLoptimizerParser {
       return null;
    }
 
-   private static Entry<String, Object> getModuleInfoFromModulesMap(Map<String, Object> modulesMap, String moduleName) {
-      if (modulesMap.containsKey(moduleName)) {
-         for (Map.Entry<String, Object> entry : modulesMap.entrySet()) {
-            if (entry.getKey().equals(moduleName)) {
-               if (log.isDebugEnabled()) {
-                  log.debug("return entry that describes module with name '" + entry.getKey() + "'");
-               }
-               return entry;
-            }
-         }
-      }
-      log.warn("Module description not found. Check correcness of name given as group members and modules name");
-      return null;
-   }
+
 
    @SuppressWarnings("unchecked")
    public static Map<String, Object> getModuleMapFromAppMap(Map<String, Object> appMap) {
@@ -695,8 +681,6 @@ public class YAMLoptimizerParser {
 
       return modulesMap;
    }
-   
-   
 
    public static Map<String, Object> getGroupMapFromAppMap(Map<String, Object> appMap) {
       Map<String, Object> groupsMap;
@@ -712,6 +696,21 @@ public class YAMLoptimizerParser {
          return null;
       }
       return groupsMap;
+   }
+
+   public static Map<String, Object> getTypesMapFromAppMap(Map<String, Object> appMap) {
+      Map<String, Object> typesMap;
+      try {
+         if (log.isDebugEnabled()) {
+            log.debug("Opening TOSCA for obtaining types");
+         }
+         typesMap = (Map<String, Object>) appMap.get(TOSCAkeywords.NODE_TYPES);
+
+      } catch (NullPointerException E) {
+         log.error("It was not found '" + TOSCAkeywords.NODE_TYPES + "' . Cannot be unveiled the types of modules");
+         return null;
+      }
+      return typesMap;
    }
 
    private static boolean moduleIsRequiredByOthers(Map<String, Object> appMap, String potentialModuleName) {
@@ -738,7 +737,20 @@ public class YAMLoptimizerParser {
          return;
       }
       modulesMap.put(key, value);
+
+   }
+
+   public static void changeModuleToScalableType(String moduleName, Map<String, Object> appMap) {
+      Map<String, Object> modulesMap = YAMLoptimizerParser.getModuleMapFromAppMap(appMap);
       
+      String typeOfModule = YAMLmodulesOptimizerParser.getModuleTypeFromModulesMap(moduleName, modulesMap);
+      
+      Map<String, Object> typesMap = (Map<String, Object>) YAMLoptimizerParser.getTypesMapFromAppMap(appMap);
+
+      if (typesMap != null) {
+         YAMLtypesOptimizerParser.changeTypeToBeScalable(typeOfModule, typesMap);
+      }
+
    }
 
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLtypesOptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLtypesOptimizerParser.java
@@ -47,4 +47,10 @@ public class YAMLtypesOptimizerParser {
       return null;
    }
 
+   public static void addComputeType(Map<String, Object> typesMap) {
+      
+      ComputeType.addComputeToTypes(typesMap);
+      
+   }
+
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLtypesOptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLtypesOptimizerParser.java
@@ -1,0 +1,50 @@
+package eu.seaclouds.platform.planner.optimizer.util;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class YAMLtypesOptimizerParser {
+
+   static Logger log = LoggerFactory.getLogger(YAMLtypesOptimizerParser.class);
+
+   public static void changeTypeToBeScalable(String typeName, Map<String, Object> typesMap) {
+
+      try {
+         Map<String, Object> typeInfo = (Map<String, Object>) typesMap.get(typeName);
+
+         if (typeInfo.containsKey(TOSCAkeywords.IS_TYPE_DERIVED_TAG)) {
+            typeInfo.put(TOSCAkeywords.IS_TYPE_DERIVED_TAG, TOSCAkeywords.NODE_TYPE_AUTOSCALABLE);
+         }
+      } catch (Exception E) {
+         // Some of the information of the type declaration was not present.
+         // Nothing to update in the type then. Logging the event
+         if (log.isDebugEnabled()) {
+            log.debug("Node type " + typeName + " could not be updated to be scalable becasue not all of its "
+                  + "information was not found in node_types part of the AAM");
+         }
+      }
+
+   }
+   
+   public static String getDerivedTypeFromTypesMap(String typeName, Map<String, Object> typesMap){
+      try {
+         Map<String, Object> typeInfo = (Map<String, Object>) typesMap.get(typeName);
+
+         if (typeInfo.containsKey(TOSCAkeywords.IS_TYPE_DERIVED_TAG)) {
+            return (String) typeInfo.get(TOSCAkeywords.IS_TYPE_DERIVED_TAG);
+         }
+         
+      } catch (Exception E) {
+         // Some of the information of the type declaration was not present.
+         // Logging the event and returning null
+         if (log.isDebugEnabled()) {
+            log.debug("Node type " + typeName + " could not be updated to be scalable becasue not all of its "
+                  + "information was not found in node_types part of the AAM");
+         }
+      }
+      return null;
+   }
+
+}

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/AbstractTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/AbstractTest.java
@@ -1,0 +1,71 @@
+package eu.seaclouds.platform.planner.optimizerTest;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.slf4j.Logger;
+
+import eu.seaclouds.platform.planner.optimizer.Optimizer;
+
+public class AbstractTest {
+
+   protected static Optimizer optimizer;
+   protected static String appModel;
+   protected static String suitableCloudOffer;
+
+   protected static Logger log;
+
+   public void openInputFiles() {
+      final String dir = System.getProperty("user.dir");
+      log.debug("Trying to open files: current executino dir = " + dir);
+
+      try {
+         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
+      } catch (IOException e) {
+         log.error("File for APPmodel not found");
+         e.printStackTrace();
+      }
+
+      try {
+         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
+      } catch (IOException e) {
+         log.error("File for Cloud Offers not found");
+         e.printStackTrace();
+      }
+      
+   }
+   
+   
+   protected static String filenameToString(String path) throws IOException {
+      byte[] encoded = Files.readAllBytes(Paths.get(path));
+      return new String(encoded, StandardCharsets.UTF_8);
+   }
+   
+   protected void saveFile(String outputFilename, String dam) {
+      PrintWriter out = null;
+      try {
+         File file = new File(outputFilename);
+         log.debug("Created file: " + outputFilename);
+         if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+         }
+         out = new PrintWriter(new FileWriter(file));
+         out.println(dam);
+      } catch (IOException e) {
+         e.printStackTrace();
+      } finally {
+         if (out != null) {
+            out.close();
+         }
+      }
+
+   }
+   
+   
+}

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerComputeTypeTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerComputeTypeTest.java
@@ -17,38 +17,21 @@
 
 package eu.seaclouds.platform.planner.optimizerTest;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.slf4j.Logger;
+
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.yaml.snakeyaml.Yaml;
 
 import eu.seaclouds.platform.planner.optimizer.Optimizer;
 import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
 import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
-import eu.seaclouds.platform.planner.optimizer.util.YAMLgroupsOptimizerParser;
-import eu.seaclouds.platform.planner.optimizer.util.YAMLmodulesOptimizerParser;
 import eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser;
-import eu.seaclouds.platform.planner.optimizer.util.YAMLtypesOptimizerParser;
 
-public class OptimizerComputeTypeTest {
-
-   private static Optimizer optimizer;
-   private static String    appModel;
-   private static String    suitableCloudOffer;
-
-   static Logger log;
+public class OptimizerComputeTypeTest extends AbstractTest {
 
    @BeforeClass
    public void createObjects() {
@@ -57,32 +40,12 @@ public class OptimizerComputeTypeTest {
 
       log.info("Starting TEST optimizer for the TOSCA syntax of September 2015");
 
-      final String dir = System.getProperty("user.dir");
-      log.debug("Trying to open files: current executino dir = " + dir);
+      openInputFiles();
 
-      try {
-         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
-      } catch (IOException e) {
-         log.error("File for APPmodel not found");
-         e.printStackTrace();
-      }
-
-      try {
-         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
-      } catch (IOException e) {
-         log.error("File for Cloud Offers not found");
-         e.printStackTrace();
-      }
-
-   }
-
-   private static String filenameToString(String path) throws IOException {
-      byte[] encoded = Files.readAllBytes(Paths.get(path));
-      return new String(encoded, StandardCharsets.UTF_8);
    }
 
    @Test(enabled = true)
-   public void testPresenceSolutionBlind() {
+   public void testPresenceOfComputeTypeInSolutionBlind() {
 
       log.info("=== TESTS FOR OPTIMIZER INCLUSION OF 'COMPUTE' TYPE IN TYPES STARTED===");
 
@@ -94,7 +57,8 @@ public class OptimizerComputeTypeTest {
          try {
             checkPresenceComputeType(arrayDam[damnum]);
          } catch (Exception e) {
-            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: " + arrayDam[damnum]);
+            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: "
+                  + arrayDam[damnum]);
             throw e;
          }
          saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.BLINDSEARCH + damnum + ".yaml", arrayDam[damnum]);
@@ -105,7 +69,7 @@ public class OptimizerComputeTypeTest {
    }
 
    @Test(enabled = true)
-   public void testPresenceSolutionHillClimb() {
+   public void testPresenceOfComputeTypeInSolutionClimb() {
 
       log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer STARTED ===");
 
@@ -117,7 +81,8 @@ public class OptimizerComputeTypeTest {
          try {
             checkPresenceComputeType(arrayDam[damnum]);
          } catch (Exception e) {
-            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: " + arrayDam[damnum]);
+            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: "
+                  + arrayDam[damnum]);
             throw e;
          }
          saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.HILLCLIMB + damnum + ".yaml", arrayDam[damnum]);
@@ -129,7 +94,7 @@ public class OptimizerComputeTypeTest {
    }
 
    @Test(enabled = true)
-   public void testPresenceSolutionAnneal() {
+   public void testPresenceOfComputeTypeInSolutionAnneal() {
 
       log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer STARTED ===");
 
@@ -141,7 +106,8 @@ public class OptimizerComputeTypeTest {
          try {
             checkPresenceComputeType(arrayDam[damnum]);
          } catch (Exception e) {
-            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: " + arrayDam[damnum]);
+            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: "
+                  + arrayDam[damnum]);
             throw e;
          }
          saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.ANNEAL + damnum + ".yaml", arrayDam[damnum]);
@@ -161,30 +127,8 @@ public class OptimizerComputeTypeTest {
 
       Map<String, Object> appMap = YAMLoptimizerParser.getMAPofAPP(dam);
       Map<String, Object> typesMap = YAMLoptimizerParser.getTypesMapFromAppMap(appMap);
-      
+
       Assert.assertTrue(typesMap.containsKey(TOSCAkeywords.COMPUTE_TYPE));
-
-
-   }
-
-
-   private void saveFile(String outputFilename, String dam) {
-      PrintWriter out = null;
-      try {
-         File file = new File(outputFilename);
-         if (!file.exists()) {
-            file.getParentFile().mkdirs();
-            file.createNewFile();
-         }
-         out = new PrintWriter(new FileWriter(file));
-         out.println(dam);
-      } catch (IOException e) {
-         e.printStackTrace();
-      } finally {
-         if (out != null) {
-            out.close();
-         }
-      }
 
    }
 

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerComputeTypeTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerComputeTypeTest.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright 2015 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package eu.seaclouds.platform.planner.optimizerTest;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import eu.seaclouds.platform.planner.optimizer.Optimizer;
+import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
+import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLgroupsOptimizerParser;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLmodulesOptimizerParser;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLtypesOptimizerParser;
+
+public class OptimizerComputeTypeTest {
+
+   private static Optimizer optimizer;
+   private static String    appModel;
+   private static String    suitableCloudOffer;
+
+   static Logger log;
+
+   @BeforeClass
+   public void createObjects() {
+
+      log = LoggerFactory.getLogger(OptimizerComputeTypeTest.class);
+
+      log.info("Starting TEST optimizer for the TOSCA syntax of September 2015");
+
+      final String dir = System.getProperty("user.dir");
+      log.debug("Trying to open files: current executino dir = " + dir);
+
+      try {
+         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
+      } catch (IOException e) {
+         log.error("File for APPmodel not found");
+         e.printStackTrace();
+      }
+
+      try {
+         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
+      } catch (IOException e) {
+         log.error("File for Cloud Offers not found");
+         e.printStackTrace();
+      }
+
+   }
+
+   private static String filenameToString(String path) throws IOException {
+      byte[] encoded = Files.readAllBytes(Paths.get(path));
+      return new String(encoded, StandardCharsets.UTF_8);
+   }
+
+   @Test(enabled = true)
+   public void testPresenceSolutionBlind() {
+
+      log.info("=== TESTS FOR OPTIMIZER INCLUSION OF 'COMPUTE' TYPE IN TYPES STARTED===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.BLINDSEARCH);
+
+      String[] arrayDam = optimizer.optimize(appModel, suitableCloudOffer);
+      for (int damnum = 0; damnum < arrayDam.length; damnum++) {
+
+         try {
+            checkPresenceComputeType(arrayDam[damnum]);
+         } catch (Exception e) {
+            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: " + arrayDam[damnum]);
+            throw e;
+         }
+         saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.BLINDSEARCH + damnum + ".yaml", arrayDam[damnum]);
+      }
+
+      log.info("=== TEST for SOLUTION GENERATION with COMPUTE type of BLIND optimizer FINISEHD ===");
+
+   }
+
+   @Test(enabled = true)
+   public void testPresenceSolutionHillClimb() {
+
+      log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer STARTED ===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.HILLCLIMB);
+
+      String[] arrayDam = optimizer.optimize(appModel, suitableCloudOffer);
+      for (int damnum = 0; damnum < arrayDam.length; damnum++) {
+
+         try {
+            checkPresenceComputeType(arrayDam[damnum]);
+         } catch (Exception e) {
+            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: " + arrayDam[damnum]);
+            throw e;
+         }
+         saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.HILLCLIMB + damnum + ".yaml", arrayDam[damnum]);
+
+      }
+
+      log.info("=== TEST for SOLUTION GENERATION with COMPUTE type of HILLCLIMB optimizer FINISEHD ===");
+
+   }
+
+   @Test(enabled = true)
+   public void testPresenceSolutionAnneal() {
+
+      log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer STARTED ===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.ANNEAL);
+
+      String[] arrayDam = optimizer.optimize(appModel, suitableCloudOffer);
+      for (int damnum = 0; damnum < arrayDam.length; damnum++) {
+
+         try {
+            checkPresenceComputeType(arrayDam[damnum]);
+         } catch (Exception e) {
+            log.error("There was an error in the check of seaclouds.nodes.Compute type in node_types. Solution was: " + arrayDam[damnum]);
+            throw e;
+         }
+         saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.ANNEAL + damnum + ".yaml", arrayDam[damnum]);
+
+      }
+
+      log.info("=== TEST for SOLUTION GENERATION with COMPUTE type of ANNEAL optimizer FINISEHD ===");
+
+   }
+
+   private void checkPresenceComputeType(String dam) {
+
+      Assert.assertFalse("Dam was not created, optimize method returns null", dam == null);
+      String damLines[] = dam.split(System.getProperty("line.separator"));
+
+      Assert.assertTrue("Dam was not created", damLines.length > 1);
+
+      Map<String, Object> appMap = YAMLoptimizerParser.getMAPofAPP(dam);
+      Map<String, Object> typesMap = YAMLoptimizerParser.getTypesMapFromAppMap(appMap);
+      
+      Assert.assertTrue(typesMap.containsKey(TOSCAkeywords.COMPUTE_TYPE));
+
+
+   }
+
+
+   private void saveFile(String outputFilename, String dam) {
+      PrintWriter out = null;
+      try {
+         File file = new File(outputFilename);
+         if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+         }
+         out = new PrintWriter(new FileWriter(file));
+         out.println(dam);
+      } catch (IOException e) {
+         e.printStackTrace();
+      } finally {
+         if (out != null) {
+            out.close();
+         }
+      }
+
+   }
+
+   @AfterClass
+   public void testFinishced() {
+      log.info("===== ALL TESTS FOR OPTIMIZER INCLUSION OF 'COMPUTE' TYPE IN TYPES FINISHED ===");
+   }
+
+}

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015AutoscalingPoliciesTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015AutoscalingPoliciesTest.java
@@ -17,22 +17,13 @@
 
 package eu.seaclouds.platform.planner.optimizerTest;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.yaml.snakeyaml.Yaml;
 
 import eu.seaclouds.platform.planner.optimizer.Optimizer;
 import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
@@ -42,13 +33,7 @@ import eu.seaclouds.platform.planner.optimizer.util.YAMLmodulesOptimizerParser;
 import eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser;
 import eu.seaclouds.platform.planner.optimizer.util.YAMLtypesOptimizerParser;
 
-public class OptimizerTOSCADecember2015AutoscalingPoliciesTest {
-
-   private static Optimizer optimizer;
-   private static String    appModel;
-   private static String    suitableCloudOffer;
-
-   static Logger log;
+public class OptimizerTOSCADecember2015AutoscalingPoliciesTest extends AbstractTest {
 
    @BeforeClass
    public void createObjects() {
@@ -56,33 +41,11 @@ public class OptimizerTOSCADecember2015AutoscalingPoliciesTest {
       log = LoggerFactory.getLogger(OptimizerTOSCADecember2015AutoscalingPoliciesTest.class);
 
       log.info("Starting TEST optimizer for the TOSCA syntax of September 2015");
-
-      final String dir = System.getProperty("user.dir");
-      log.debug("Trying to open files: current executino dir = " + dir);
-
-      try {
-         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
-      } catch (IOException e) {
-         log.error("File for APPmodel not found");
-         e.printStackTrace();
-      }
-
-      try {
-         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
-      } catch (IOException e) {
-         log.error("File for Cloud Offers not found");
-         e.printStackTrace();
-      }
-
-   }
-
-   private static String filenameToString(String path) throws IOException {
-      byte[] encoded = Files.readAllBytes(Paths.get(path));
-      return new String(encoded, StandardCharsets.UTF_8);
+      openInputFiles();
    }
 
    @Test(enabled = true)
-   public void testPresenceSolutionBlind() {
+   public void testPresenceAutoscalingPoliciesInSolutionBlind() {
 
       log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer STARTED (syntax December 2015)===");
 
@@ -105,7 +68,7 @@ public class OptimizerTOSCADecember2015AutoscalingPoliciesTest {
    }
 
    @Test(enabled = true)
-   public void testPresenceSolutionHillClimb() {
+   public void testPresenceAutoscalingPoliciesInSolutionHillClimb() {
 
       log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer STARTED ===");
 
@@ -129,7 +92,7 @@ public class OptimizerTOSCADecember2015AutoscalingPoliciesTest {
    }
 
    @Test(enabled = true)
-   public void testPresenceSolutionAnneal() {
+   public void testPresenceAutoscalingPoliciesInSolutionAnneal() {
 
       log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer STARTED ===");
 
@@ -165,17 +128,25 @@ public class OptimizerTOSCADecember2015AutoscalingPoliciesTest {
       Map<String, Object> groupsMap = YAMLoptimizerParser.getGroupMapFromAppMap(appMap);
 
       for (Map.Entry<String, Object> entry : nodesMap.entrySet()) {
-         if (canScale((Map<String, Object>) entry.getValue()) && (requirementsSatisfied(appMap, groupsMap))) {
-            Assert.assertNotNull(
-                  getAutoScalingPolicy(YAMLgroupsOptimizerParser.findGroupOfMemberName(entry.getKey(), groupsMap)));
+         if (canScale(entry) && (requirementsSatisfied(appMap, groupsMap))) {
+            Map<String, Object> autoscalingPolicy = getAutoScalingPolicy(
+                  YAMLgroupsOptimizerParser.findGroupOfMemberName(entry.getKey(), groupsMap));
+            if (autoscalingPolicy != null) {
+               Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_POOL_MAXIMUM_SIZE));
+               Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_METRIC));
+               Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_METRIC_LOWERBOUND));
+               Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_METRIC_UPPERBOUND));
+               Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_POOL_MINIMUM_SIZE));
 
-            String typeOfNode = YAMLmodulesOptimizerParser.getModuleTypeFromModulesMap(entry.getKey(), nodesMap);
-            Assert.assertNotNull("Type of node " + entry.getKey() + " was NULL", typeOfNode);
-            Assert.assertTrue(
-                  "Types in node_types were not created well for module " + entry.getKey() + " type found for it was: "
-                        + YAMLtypesOptimizerParser.getDerivedTypeFromTypesMap(typeOfNode, typesMap),
-                  TOSCAkeywords.NODE_TYPE_AUTOSCALABLE
-                        .equals(YAMLtypesOptimizerParser.getDerivedTypeFromTypesMap(typeOfNode, typesMap)));
+               String typeOfNode = YAMLmodulesOptimizerParser.getModuleTypeFromModulesMap(entry.getKey(), nodesMap);
+               Assert.assertNotNull("Type of node " + entry.getKey() + " was NULL", typeOfNode);
+               Assert.assertTrue(
+                     "Types in node_types were not created well for module " + entry.getKey()
+                           + " type found for it was: "
+                           + YAMLtypesOptimizerParser.getDerivedTypeFromTypesMap(typeOfNode, typesMap),
+                     TOSCAkeywords.NODE_TYPE_AUTOSCALABLE
+                           .equals(YAMLtypesOptimizerParser.getDerivedTypeFromTypesMap(typeOfNode, typesMap)));
+            }
          }
       }
 
@@ -187,49 +158,31 @@ public class OptimizerTOSCADecember2015AutoscalingPoliciesTest {
                YAMLgroupsOptimizerParser.findGroupOfMemberName(YAMLoptimizerParser.getInitialElementName(appMap),
                      groupsMap),
                TOSCAkeywords.EXPECTED_QUALITY_PROPERTIES);
-         return (boolean) qualitySol.get(TOSCAkeywords.OVERALL_QOS_FITNESS);
+         return (boolean) (((Double) qualitySol.get(TOSCAkeywords.OVERALL_QOS_FITNESS)) > 1.0);
       } catch (Exception E) {
          // Something among the many pieces of information for specifying the
          // expected QoS was not present
          // So the it was not specified that the requirements were satisfied.
+         log.info("Checking if requirements were satisfied we have received the exception: " + E.getClass());
          return false;
       }
    }
 
-   private Object getAutoScalingPolicy(Map<String, Object> groupMap) {
+   private Map<String, Object> getAutoScalingPolicy(Map<String, Object> groupMap) {
       return YAMLgroupsOptimizerParser.getPolicySubInfoFromGroupInfo(groupMap, TOSCAkeywords.AUTOSCALING_TAG);
    }
 
    @SuppressWarnings("unchecked")
-   private boolean canScale(Map<String, Object> node) {
+   private boolean canScale(Map.Entry<String, Object> module) {
+      Map<String, Object> moduleInfo = (Map<String, Object>) module.getValue();
       try {
-         return (boolean) ((Map<String, Object>) node.get(TOSCAkeywords.MODULE_PROPERTIES_TAG))
+         return (boolean) ((Map<String, Object>) moduleInfo.get(TOSCAkeywords.MODULE_PROPERTIES_TAG))
                .get(TOSCAkeywords.MODULE_AUTOSCALE_PROPERTY);
 
       } catch (Exception E) {
-
+         log.info("It was not found autoscale definition for module " + module.getKey());
          return false;
       }
-   }
-
-   private void saveFile(String outputFilename, String dam) {
-      PrintWriter out = null;
-      try {
-         File file = new File(outputFilename);
-         if (!file.exists()) {
-            file.getParentFile().mkdirs();
-            file.createNewFile();
-         }
-         out = new PrintWriter(new FileWriter(file));
-         out.println(dam);
-      } catch (IOException e) {
-         e.printStackTrace();
-      } finally {
-         if (out != null) {
-            out.close();
-         }
-      }
-
    }
 
    @AfterClass

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015AutoscalingPoliciesTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015AutoscalingPoliciesTest.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2015 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package eu.seaclouds.platform.planner.optimizerTest;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import eu.seaclouds.platform.planner.optimizer.Optimizer;
+import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
+import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLgroupsOptimizerParser;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLmodulesOptimizerParser;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLtypesOptimizerParser;
+
+public class OptimizerTOSCADecember2015AutoscalingPoliciesTest {
+
+   private static Optimizer optimizer;
+   private static String    appModel;
+   private static String    suitableCloudOffer;
+
+   static Logger log;
+
+   @BeforeClass
+   public void createObjects() {
+
+      log = LoggerFactory.getLogger(OptimizerTOSCADecember2015AutoscalingPoliciesTest.class);
+
+      log.info("Starting TEST optimizer for the TOSCA syntax of September 2015");
+
+      final String dir = System.getProperty("user.dir");
+      log.debug("Trying to open files: current executino dir = " + dir);
+
+      try {
+         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
+      } catch (IOException e) {
+         log.error("File for APPmodel not found");
+         e.printStackTrace();
+      }
+
+      try {
+         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
+      } catch (IOException e) {
+         log.error("File for Cloud Offers not found");
+         e.printStackTrace();
+      }
+
+   }
+
+   private static String filenameToString(String path) throws IOException {
+      byte[] encoded = Files.readAllBytes(Paths.get(path));
+      return new String(encoded, StandardCharsets.UTF_8);
+   }
+
+   @Test(enabled = true)
+   public void testPresenceSolutionBlind() {
+
+      log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer STARTED (syntax December 2015)===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.BLINDSEARCH);
+
+      String[] arrayDam = optimizer.optimize(appModel, suitableCloudOffer);
+      for (int damnum = 0; damnum < arrayDam.length; damnum++) {
+
+         try {
+            checkAutoscalingPolicies(arrayDam[damnum]);
+         } catch (Exception e) {
+            log.error("There was an error in the check of policies. Solution was: " + arrayDam[damnum]);
+            throw e;
+         }
+         saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.BLINDSEARCH + damnum + ".yaml", arrayDam[damnum]);
+      }
+
+      log.info("=== TEST for SOLUTION GENERATION with POLICIES of BLIND optimizer FINISEHD ===");
+
+   }
+
+   @Test(enabled = true)
+   public void testPresenceSolutionHillClimb() {
+
+      log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer STARTED ===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.HILLCLIMB);
+
+      String[] arrayDam = optimizer.optimize(appModel, suitableCloudOffer);
+      for (int damnum = 0; damnum < arrayDam.length; damnum++) {
+
+         try {
+            checkAutoscalingPolicies(arrayDam[damnum]);
+         } catch (Exception e) {
+            log.error("There was an error in the check of policies. Solution was: " + arrayDam[damnum]);
+            throw e;
+         }
+         saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.HILLCLIMB + damnum + ".yaml", arrayDam[damnum]);
+
+      }
+
+      log.info("=== TEST for SOLUTION GENERATION with POLICIES of HILLCLIMB optimizer FINISEHD ===");
+
+   }
+
+   @Test(enabled = true)
+   public void testPresenceSolutionAnneal() {
+
+      log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer STARTED ===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.ANNEAL);
+
+      String[] arrayDam = optimizer.optimize(appModel, suitableCloudOffer);
+      for (int damnum = 0; damnum < arrayDam.length; damnum++) {
+
+         try {
+            checkAutoscalingPolicies(arrayDam[damnum]);
+         } catch (Exception e) {
+            log.error("There was an error in the check of policies. Solution was: " + arrayDam[damnum]);
+            throw e;
+         }
+         saveFile(TestConstants.OUTPUT_FILENAME + SearchMethodName.ANNEAL + damnum + ".yaml", arrayDam[damnum]);
+
+      }
+
+      log.info("=== TEST for SOLUTION GENERATION with POLICIES of ANNEAL optimizer FINISEHD ===");
+
+   }
+
+   private void checkAutoscalingPolicies(String dam) {
+
+      Assert.assertFalse("Dam was not created, optimize method returns null", dam == null);
+      String damLines[] = dam.split(System.getProperty("line.separator"));
+
+      Assert.assertTrue("Dam was not created", damLines.length > 1);
+
+      Map<String, Object> appMap = YAMLoptimizerParser.getMAPofAPP(dam);
+      Map<String, Object> nodesMap = YAMLoptimizerParser.getModuleMapFromAppMap(appMap);
+      Map<String, Object> typesMap = YAMLoptimizerParser.getTypesMapFromAppMap(appMap);
+      Map<String, Object> groupsMap = YAMLoptimizerParser.getGroupMapFromAppMap(appMap);
+
+      for (Map.Entry<String, Object> entry : nodesMap.entrySet()) {
+         if (canScale((Map<String, Object>) entry.getValue()) && (requirementsSatisfied(appMap, groupsMap))) {
+            Assert.assertNotNull(
+                  getAutoScalingPolicy(YAMLgroupsOptimizerParser.findGroupOfMemberName(entry.getKey(), groupsMap)));
+
+            String typeOfNode = YAMLmodulesOptimizerParser.getModuleTypeFromModulesMap(entry.getKey(), nodesMap);
+            Assert.assertNotNull("Type of node " + entry.getKey() + " was NULL", typeOfNode);
+            Assert.assertTrue(
+                  "Types in node_types were not created well for module " + entry.getKey() + " type found for it was: "
+                        + YAMLtypesOptimizerParser.getDerivedTypeFromTypesMap(typeOfNode, typesMap),
+                  TOSCAkeywords.NODE_TYPE_AUTOSCALABLE
+                        .equals(YAMLtypesOptimizerParser.getDerivedTypeFromTypesMap(typeOfNode, typesMap)));
+         }
+      }
+
+   }
+
+   private boolean requirementsSatisfied(Map<String, Object> appMap, Map<String, Object> groupsMap) {
+      try {
+         Map<String, Object> qualitySol = YAMLgroupsOptimizerParser.getPolicySubInfoFromGroupInfo(
+               YAMLgroupsOptimizerParser.findGroupOfMemberName(YAMLoptimizerParser.getInitialElementName(appMap),
+                     groupsMap),
+               TOSCAkeywords.EXPECTED_QUALITY_PROPERTIES);
+         return (boolean) qualitySol.get(TOSCAkeywords.OVERALL_QOS_FITNESS);
+      } catch (Exception E) {
+         // Something among the many pieces of information for specifying the
+         // expected QoS was not present
+         // So the it was not specified that the requirements were satisfied.
+         return false;
+      }
+   }
+
+   private Object getAutoScalingPolicy(Map<String, Object> groupMap) {
+      return YAMLgroupsOptimizerParser.getPolicySubInfoFromGroupInfo(groupMap, TOSCAkeywords.AUTOSCALING_TAG);
+   }
+
+   @SuppressWarnings("unchecked")
+   private boolean canScale(Map<String, Object> node) {
+      try {
+         return (boolean) ((Map<String, Object>) node.get(TOSCAkeywords.MODULE_PROPERTIES_TAG))
+               .get(TOSCAkeywords.MODULE_AUTOSCALE_PROPERTY);
+
+      } catch (Exception E) {
+
+         return false;
+      }
+   }
+
+   private void saveFile(String outputFilename, String dam) {
+      PrintWriter out = null;
+      try {
+         File file = new File(outputFilename);
+         if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+         }
+         out = new PrintWriter(new FileWriter(file));
+         out.println(dam);
+      } catch (IOException e) {
+         e.printStackTrace();
+      } finally {
+         if (out != null) {
+            out.close();
+         }
+      }
+
+   }
+
+   @AfterClass
+   public void testFinishced() {
+      log.info("===== ALL TESTS FOR OPTIMIZER USING DECEMBER 2015 TOSCA FINISHED ===");
+   }
+
+}

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCASeptember2015Test.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCASeptember2015Test.java
@@ -17,22 +17,14 @@
 
 package eu.seaclouds.platform.planner.optimizerTest;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Map;
 
 import org.junit.Assert;
-import org.slf4j.Logger;
+
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.yaml.snakeyaml.Yaml;
 
 import eu.seaclouds.platform.planner.optimizer.Optimizer;
 import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
@@ -40,13 +32,8 @@ import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
 import eu.seaclouds.platform.planner.optimizer.util.YAMLgroupsOptimizerParser;
 import eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser;
 
-public class OptimizerTOSCASeptember2015Test {
-
-   private static Optimizer optimizer;
-   private static String appModel;
-   private static String suitableCloudOffer;
-
-   static Logger log;
+@Test(enabled = false)
+public class OptimizerTOSCASeptember2015Test extends AbstractTest {
 
    @BeforeClass
    public void createObjects() {
@@ -55,34 +42,13 @@ public class OptimizerTOSCASeptember2015Test {
 
       log.info("Starting TEST optimizer for the TOSCA syntax of September 2015");
 
-      final String dir = System.getProperty("user.dir");
-      log.debug("Trying to open files: current executino dir = " + dir);
-
-      try {
-         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
-      } catch (IOException e) {
-         log.error("File for APPmodel not found");
-         e.printStackTrace();
-      }
-
-      try {
-         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
-      } catch (IOException e) {
-         log.error("File for Cloud Offers not found");
-         e.printStackTrace();
-      }
+      openInputFiles();
 
    }
 
-   private static String filenameToString(String path) throws IOException {
-      byte[] encoded = Files.readAllBytes(Paths.get(path));
-      return new String(encoded, StandardCharsets.UTF_8);
-   }
-
-   @Test(enabled = true)
    public void testPresenceSolutionBlind() {
 
-      log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer STARTED (syntax July 2015)===");
+      log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer STARTED (syntax September 2015)===");
 
       optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.BLINDSEARCH);
 
@@ -102,7 +68,6 @@ public class OptimizerTOSCASeptember2015Test {
 
    }
 
-   @Test(enabled = true)
    public void testPresenceSolutionHillClimb() {
 
       log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer STARTED ===");
@@ -126,7 +91,6 @@ public class OptimizerTOSCASeptember2015Test {
 
    }
 
-   @Test(enabled = true)
    public void testPresenceSolutionAnneal() {
 
       log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer STARTED ===");
@@ -229,26 +193,6 @@ public class OptimizerTOSCASeptember2015Test {
 
          return false;
       }
-   }
-
-   private void saveFile(String outputFilename, String dam) {
-      PrintWriter out = null;
-      try {
-         File file = new File(outputFilename);
-         if (!file.exists()) {
-            file.getParentFile().mkdirs();
-            file.createNewFile();
-         }
-         out = new PrintWriter(new FileWriter(file));
-         out.println(dam);
-      } catch (IOException e) {
-         e.printStackTrace();
-      } finally {
-         if (out != null) {
-            out.close();
-         }
-      }
-
    }
 
    @AfterClass

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCAjuly2015Test.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCAjuly2015Test.java
@@ -17,19 +17,9 @@
 
 package eu.seaclouds.platform.planner.optimizerTest;
 
-
-import static org.junit.Assert.*;
-
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import org.junit.Assert;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -39,29 +29,20 @@ import eu.seaclouds.platform.planner.optimizer.Optimizer;
 import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
 import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
 
-public class OptimizerTOSCAjuly2015Test {
+public class OptimizerTOSCAjuly2015Test extends AbstractTest {
 
-   private static Optimizer optimizer;
-   private static String appModel;
-   private static String suitableCloudOffer;
-   private static final String APP_MODEL_FILENAME = "./src/test/java/eu/seaclouds/platform/planner/optimizerTest/resources/aam.yml";
-   private static final String CLOUD_OFFER_FILENAME = "./src/test/java/eu/seaclouds/platform/planner/optimizerTest/resources/cloudOfferWithQoS.yaml";
-   private static final String OUTPUT_FILENAME = "./src/test/java/eu/seaclouds/platform/planner/optimizerTest/resources/target/outputNewTOSCA";
-   private static final String OPEN_SQUARE_BRACKET = "[";
-   private static final String CLOSE_SQUARE_BRACKET = "]";
-   private static final double MAX_MILLIS_EXECUTING = 20000;
+   private static final String APP_MODEL_FILENAME_JULY15   = "./src/test/java/eu/seaclouds/platform/planner/optimizerTest/resources/aam.yml";
+   private static final String CLOUD_OFFER_FILENAME_JULY15 = "./src/test/java/eu/seaclouds/platform/planner/optimizerTest/resources/cloudOfferWithQoS.yaml";
+   private static final String OUTPUT_FILENAME_JULY15      = "./src/test/java/eu/seaclouds/platform/planner/optimizerTest/resources/target/outputNewTOSCA";
+   private static final String OPEN_SQUARE_BRACKET         = "[";
+   private static final String CLOSE_SQUARE_BRACKET        = "]";
 
    private static final int NUM_PLANS_TO_GENERATE = 5;
-
-   static Logger log;
-
-
 
    @BeforeClass
    public void createObjects() {
 
       log = LoggerFactory.getLogger(OptimizerTOSCAjuly2015Test.class);
-
 
       log.info("Starting TEST optimizer for the TOSCA syntax of July 2015");
 
@@ -69,24 +50,19 @@ public class OptimizerTOSCAjuly2015Test {
       log.debug("Trying to open files: current executino dir = " + dir);
 
       try {
-         appModel = filenameToString(APP_MODEL_FILENAME);
+         appModel = filenameToString(APP_MODEL_FILENAME_JULY15);
       } catch (IOException e) {
          log.error("File for APPmodel not found");
          e.printStackTrace();
       }
 
       try {
-         suitableCloudOffer = filenameToString(CLOUD_OFFER_FILENAME);
+         suitableCloudOffer = filenameToString(CLOUD_OFFER_FILENAME_JULY15);
       } catch (IOException e) {
          log.error("File for Cloud Offers not found");
          e.printStackTrace();
       }
 
-   }
-
-   private static String filenameToString(String path) throws IOException {
-      byte[] encoded = Files.readAllBytes(Paths.get(path));
-      return new String(encoded, StandardCharsets.UTF_8);
    }
 
    @Test(enabled = false)
@@ -105,7 +81,7 @@ public class OptimizerTOSCAjuly2015Test {
             log.error("There was an error in the check of correctness. Solution was: " + arrayDam[damnum]);
             throw e;
          }
-         saveFile(OUTPUT_FILENAME + SearchMethodName.BLINDSEARCH + damnum + ".yaml", arrayDam[damnum]);
+         saveFile(OUTPUT_FILENAME_JULY15 + SearchMethodName.BLINDSEARCH + damnum + ".yaml", arrayDam[damnum]);
       }
 
       log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer FINISEHD ===");
@@ -141,26 +117,6 @@ public class OptimizerTOSCAjuly2015Test {
          }
       }
       Assert.assertEquals("Optimizer did not find any of the services", numServices, numSuitableServicesFound);
-
-   }
-
-   private void saveFile(String outputFilename, String dam) {
-      PrintWriter out = null;
-      try {
-         File file = new File(outputFilename);
-         if (!file.exists()) {
-            file.getParentFile().mkdirs();
-            file.createNewFile();
-         }
-         out = new PrintWriter(new FileWriter(file));
-         out.println(dam);
-      } catch (IOException e) {
-         e.printStackTrace();
-      } finally {
-         if (out != null) {
-            out.close();
-         }
-      }
 
    }
 

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTest.java
@@ -17,16 +17,7 @@
 
 package eu.seaclouds.platform.planner.optimizerTest;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
 import org.junit.Assert;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -36,13 +27,7 @@ import eu.seaclouds.platform.planner.optimizer.Optimizer;
 import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
 import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
 
-public class OptimizerTest {
-
-   private static Optimizer optimizer;
-   private static String appModel;
-   private static String suitableCloudOffer;
-
-   static Logger log;
+public class OptimizerTest extends AbstractTest {
 
    @BeforeClass
    public void createObjects() {
@@ -50,28 +35,8 @@ public class OptimizerTest {
       log = LoggerFactory.getLogger(OptimizerTest.class);
       log.info("Starting TEST optimizer");
 
-      final String dir = System.getProperty("user.dir");
-      log.debug("Trying to open files: current executino dir = " + dir);
+      openInputFiles();
 
-      try {
-         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
-      } catch (IOException e) {
-         log.error("File for APPmodel not found");
-         e.printStackTrace();
-      }
-
-      try {
-         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
-      } catch (IOException e) {
-         log.error("File for Cloud Offers not found");
-         e.printStackTrace();
-      }
-
-   }
-
-   private static String filenameToString(String path) throws IOException {
-      byte[] encoded = Files.readAllBytes(Paths.get(path));
-      return new String(encoded, StandardCharsets.UTF_8);
    }
 
    @Test(enabled = TestConstants.EnabledTest)
@@ -175,27 +140,6 @@ public class OptimizerTest {
          }
       }
       Assert.assertEquals("Optimizer did not find any of the services", numServices, numSuitableServicesFound);
-
-   }
-
-   private void saveFile(String outputFilename, String dam) {
-      PrintWriter out = null;
-      try {
-         File file = new File(outputFilename);
-         log.debug("Created file: " + outputFilename);
-         if (!file.exists()) {
-            file.getParentFile().mkdirs();
-            file.createNewFile();
-         }
-         out = new PrintWriter(new FileWriter(file));
-         out.println(dam);
-      } catch (IOException e) {
-         e.printStackTrace();
-      } finally {
-         if (out != null) {
-            out.close();
-         }
-      }
 
    }
 

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/TestConstants.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/TestConstants.java
@@ -4,7 +4,7 @@ public class TestConstants {
 
    public static final boolean EnabledTest = true;
    
-   public static final String APP_MODEL_FILENAME    = "./src/test/resources/aam_atos_case_study20Oct.yml";
+   public static final String APP_MODEL_FILENAME    = "./src/test/resources/aam_atos_case_study10Dec.yml";
 
    
    public static final String CLOUD_OFFER_FILENAME_IN_DIRECTMAP  = "./src/test/resources/MMoutputV-15-09.yml";

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/TestConstants.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/TestConstants.java
@@ -9,7 +9,7 @@ public class TestConstants {
    
    public static final String CLOUD_OFFER_FILENAME_IN_DIRECTMAP  = "./src/test/resources/MMoutputV-15-09.yml";
 
-   public static final String OUTPUT_FILENAME       = "./src/test/target/outputNewTOSCAasService";
+   public static final String OUTPUT_FILENAME       = "./src/test/target/outputNewTOSCAwithPolicies";
    public static final String OPEN_SQUARE_BRACKET   = "[";
    public static final String CLOSE_SQUARE_BRACKET  = "]";
    public static final double MAX_MILLIS_EXECUTING  = 20000;

--- a/planner/optimizer/optimizer-core/src/test/resources/aam_atos_case_study10Dec.yml
+++ b/planner/optimizer/optimizer-core/src/test/resources/aam_atos_case_study10Dec.yml
@@ -1,0 +1,115 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+description: 3tier example
+imports:
+- tosca-normative-types:1.0.0.wd03-SNAPSHOT
+topology_template:
+  node_templates:
+    www:
+      type: sc_req.www
+      properties:
+        language: JAVA
+        location: DYNAMIC
+        location_option: FOLLOW_SUN
+        autoscale: true
+      requirements:
+      - endpoint: webservices
+    webservices:
+      type: sc_req.webservices
+      properties:
+        language: JAVA
+        location: STATIC
+        location_option: EUROPE
+        autoscale: false
+        java_version:
+          constraints:
+          - greater_or_equal: '7'
+          - less_or_equal: '8'
+      requirements:
+      - endpoint: db1
+    db1:
+      type: sc_req.db1
+      properties:
+        mysql_version:
+          constraints:
+          - greater_or_equal: '5.0'
+          - less_or_equal: '5.6'
+node_types:
+  sc_req.www:
+    derived_from: seaclouds.nodes.webapp.tomcat.TomcatServer
+    properties:
+      java_support:
+        constraints:
+        - equal: true
+      tomcat_support:
+        constraints:
+        - equal: true
+      java_version:
+        constraints:
+        - greater_or_equal: '7'
+        - less_or_equal: '8'
+      resource_type:
+        constraints:
+        - equal: platform
+  sc_req.webservices:
+    derived_from: seaclouds.nodes.SoftwareComponent
+    properties:
+      num_cpus:
+        constraints:
+        - greater_or_equal: '4'
+      disk_size:
+        constraints:
+        - greater_or_equal: '256'
+      resource_type:
+        constraints:
+        - equal: compute
+  sc_req.db1:
+    derived_from: seaclouds.nodes.database.mysql.MySqlNode
+    properties:
+      mysql_support:
+        constraints:
+        - equal: true
+      mysql_version:
+        constraints:
+        - greater_or_equal: '5.0'
+        - less_or_equal: '5.6'
+groups:
+  operation_www:
+    members:
+    - www
+    policies:
+    - QoSInfo:
+        execution_time: 200 ms
+        benchmark_platform: Amazon_EC2_m3_xlarge_eu_central_1
+    - dependencies:
+        operation_webservices: '2'
+    - AppQoSRequirements:
+        response_time:
+          less_than: 2000.0 ms
+        availability:
+          greater_than: 0.98
+        cost:
+          less_or_equal: 2000.0 euros_per_month
+        workload:
+          less_or_equal: 50.0 req_per_min
+  operation_webservices:
+    members:
+    - webservices
+    policies:
+    - QoSInfo:
+        execution_time: 100 ms
+        benchmark_platform: Amazon_EC2_m3_xlarge_eu_central_1
+    - dependencies:
+        operation_db1: '1'
+    - QoSRequirements:
+        AverageResponseTime:
+          less_than: 1000.0 ms
+        AppAvailable:
+          greater_than: 99.8
+  operation_db1:
+    members:
+    - db1
+    policies:
+    - dependencies: {}
+    - QoSInfo:
+        execution_time: 50 ms
+        benchmark_platform: Amazon_EC2_m3_xlarge_eu_central_1

--- a/planner/optimizer/optimizer-core/src/test/resources/log4j.xml
+++ b/planner/optimizer/optimizer-core/src/test/resources/log4j.xml
@@ -17,11 +17,10 @@
 		</layout>
 	</appender>
 
-	<logger
-		name="eu.seaclouds.platform.planner.optimizer.Topology">
+	<logger name="eu.seaclouds.platform.planner.optimizer.Topology">
 		<level value="info" />
 	</logger>
-	
+
 	<logger
 		name="eu.seaclouds.platform.planner.optimizer.heuristics.AbstractHeuristic">
 		<level value="info" />
@@ -46,6 +45,11 @@
 	</logger>
 	<logger
 		name="eu.seaclouds.platform.planner.optimizer.util.YAMLmodulesOptimizerParser">
+		<level value="info" />
+	</logger>
+
+	<logger
+		name="eu.seaclouds.platform.planner.optimizer.util.YAMLtypesOptimizerParser">
 		<level value="info" />
 	</logger>
 

--- a/planner/optimizer/optimizer-core/src/test/resources/log4j.xml
+++ b/planner/optimizer/optimizer-core/src/test/resources/log4j.xml
@@ -57,6 +57,12 @@
 		name="eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser">
 		<level value="info" />
 	</logger>
+	
+		<logger
+		name="eu.seaclouds.platform.planner.optimizer.util.ComputeType">
+		<level value="info" />
+	</logger>
+	
 	<logger
 		name="eu.seaclouds.platform.planner.optimizer.OptimizerInitialDeployment">
 		<level value="info" />


### PR DESCRIPTION
In the current state there are modules with which there are autoscaling policies associated. However such modules do not belong to scalable types.

This PR addresses it, by changing the type of the modules that have associated autoscaling policies to seaclouds.nodes.ControlledDynamicWebAppCluster.

This PR also creates seaclouds.nodes.Compute type in node_types. 

Tests have been created to check that changes in the types have been produced in the correct nodes.

You can see that I've not squashed the commits. I've done it on purpose. I would like @rosogon looking at the two firsts because they are related to his PR that is currently failing. I thought it would be clearer for him if I do not squash all the changes into one already from the beginning.