### PR TITLE
AAMWriter: Replace Snake YAML default line ending with the OS default one.

### DIFF
--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/AamWriter.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/AamWriter.java
@@ -69,6 +69,7 @@ public class AamWriter {
     
     private String dumpYaml(Aam aam) {
         DumperOptions options = new DumperOptions();
+        options.setLineBreak(DumperOptions.LineBreak.getPlatformLineBreak());
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         Yaml yamlParser = new Yaml(options);
         


### PR DESCRIPTION
This allows the AAMWritter to dump YAML with the proper line ending according to the SO which is running SeaClouds. By default Snake YAML uses UNIX line ending [1] causing problems in comparisons between generated AAM and existing AAM in the filesystem (useful for tests).

@rosogon  could you take a look?

[1] https://bitbucket.org/asomov/snakeyaml/src/c27fdd906c8f651baa6ee2232cc7b56c724439b8/src/main/java/org/yaml/snakeyaml/DumperOptions.java?at=default&fileviewer=file-view-default#DumperOptions.java-168