### PR TITLE
Adding first brooklyn-tosca support.

### DIFF
--- a/byon/files/seaclouds-catalog.bom
+++ b/byon/files/seaclouds-catalog.bom
@@ -193,6 +193,7 @@ brooklyn.catalog:
         brooklynnode.webconsole.nosecurity: true
         brooklynnode.classpath:
           - https://s3-eu-west-1.amazonaws.com/seaclouds-deployer/deployer-0.9.0-20161101.16.20.24-46.jar
+          - https://s3-eu-west-1.amazonaws.com/tosca-temporal-integration/brooklyn-tosca-transformer-0.9.0-SNAPSHOT-20161201.114217.jar
       brooklyn.enrichers:
         - enricherType: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:


### PR DESCRIPTION
Adding first brooklyn TOSCA support to SeaClouds Deployer.
Next step would be to use maven instead of a fixed jar.