### PR TITLE
Fix/aam relationships

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
@@ -115,7 +115,7 @@
                                     <tbody>
                                     <tr>
                                         <td>
-                                            <input type="text" class="form-control" name="metric">
+                                            <select class="form-control" name="metric" id="nf-qos-metric"/>
                                         <td>
                                             <select class="form-control" name="operator" id="nf-qos-operator">
                                                 <option value=""></option>
@@ -126,7 +126,7 @@
                                                 <option value="GT">&gt;</option>
                                             </select>
                                         <td>
-                                            <input type="text" class="form-control" name="threshold">
+                                            <input type="text" class="form-control" id="nf-qos-threshold" name="threshold">
                                         <td>
                                             <select class="form-control" name="action" id="nf-qos-action">
                                                 <option value=""></option>
@@ -227,6 +227,15 @@
                     <form role="form">
                         <fieldset id="set-operations">
                             <legend>Description</legend>
+                            <div class="form-group">
+                                <label for="operation-type">Operation type</label>
+                                <select class="form-control" id="operation-type"> </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="operation-credentials-file">File where to store credentials</label>
+                                <input type="text" class="form-control" id="operation-credentials-file"
+                                       placeholder="database.properties">
+                            </div>
                             <div class="form-group">
                                 <label for="operation-calls">Average number of calls</label>
                                 <input type="text" class="form-control" id="operation-calls" placeholder="1">

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -59,7 +59,8 @@ var Editor = (function() {
                 "": ""
             },
         "PHP": {
-                "": ""
+                "": "",
+                "php.httpd.PhpHttpdServer": "Apache"
             }
     }
 
@@ -119,7 +120,9 @@ var Editor = (function() {
     };
 
     var operation_types = {
-        "seaclouds.relationships.Configure": "Configure"
+        "seaclouds.relations.databaseconnections.jdbc": "JDBC connection",
+        "seaclouds.relations.databaseconnections.php": "PHP-db connection",
+        "seaclouds.relation.connection.endpoint.host": "HTTP connection"
     };
 
     /*

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -65,6 +65,7 @@ var Editor = (function() {
     }
 
     var database_options = {
+        "": "",
         "database.mysql.MySqlNode": "MySql",
         "database.mariadb.MariaDbNode": "mariadb",
         "database.postgresql.PostgreSqlNode": "PostgreSQL",

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -118,6 +118,10 @@ var Editor = (function() {
         "hp_cloud_services.2xl": "hp_cloud_services.2xl"
     };
 
+    var operation_types = {
+        "seaclouds.relationships.Configure": "Configure"
+    };
+
     /*
      * Override some Link and Node methods regarding Canvas.
      */
@@ -479,7 +483,6 @@ var Editor = (function() {
         );
         $("#database-min-version").val(node.properties.min_version);
         $("#database-max-version").val(node.properties.max_version);
-
     };
 
     databasetechset.store = function(node) {
@@ -645,15 +648,20 @@ var Editor = (function() {
     operationsset.operationsset = function(fieldsetid) {
         this.setup(fieldsetid);
 
+        Forms.populate_select($("#operation-type"), operation_types);
         return this;
     }
 
     operationsset.load = function(link) {
         $("#operation-calls").val(link.properties.calls);
+        $("#operation-credentials-file").val(link.properties.credentials_file);
+        $("#operation-type").val(link.properties.operation_type);
     };
 
     operationsset.store = function(link) {
         link.properties.calls = $("#operation-calls").val();
+        link.properties.credentials_file = $("#operation-credentials-file").val();
+        link.properties.operation_type = $("#operation-type").val();
     };
 
     var fromjson = function(json) {

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
@@ -199,7 +199,10 @@ public class Translator {
         NodeTemplate source = topologyTemplate.getNodeTemplate(dSource.getName());
         NodeTemplate target = topologyTemplate.getNodeTemplate(dTarget.getName());
         
-        source.addConnectionRequirement(target);
+        source.addConnectionRequirement(target, l.getOperationType());
+        if (!l.getCredentialsFile().isEmpty()) {
+            source.addProperty(DLink.Attributes.CREDENTIALS_FILE, l.getCredentialsFile());
+        }
     }
 
     private void buildGroups(DGraph dgraph, Aam aam) {

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/NodeTemplate.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/NodeTemplate.java
@@ -95,11 +95,12 @@ public class NodeTemplate extends LinkedHashMap {
      * Add an endpoint requirement to a NodeTemplate
      * @return name given to the requirement
      */
-    public String addConnectionRequirement(NodeTemplate target) {
+    public String addConnectionRequirement(NodeTemplate target, String type) {
         Map<String, String> requirement = new LinkedHashMap();
         
         String requirementName = "endpoint";
         requirement.put(requirementName, target.getName());
+        requirement.put("type", type);
         requirements().add(requirement);
         
         return requirementName;

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DLink.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DLink.java
@@ -29,6 +29,8 @@ public class DLink {
         public static final String PROPERTIES = "properties";
 
         public static final String CALLS = "calls";
+        public static final String TYPE = "operation_type";
+        public static final String CREDENTIALS_FILE = "credentials_file";
     }
 
     private DGraph graph;
@@ -36,6 +38,8 @@ public class DLink {
     private DNode target;
     private Map<String, String> properties;
     private String calls;
+    private String operationType;
+    private String credentialsFile;
 
     public DLink(JSONObject jnode, DGraph graph) {
         this.graph = graph;
@@ -51,6 +55,8 @@ public class DLink {
         this.properties = new HashMap<String, String>();
         this.properties.putAll(linkProperties);
         this.calls = properties.containsKey(Attributes.CALLS)? properties.get(Attributes.CALLS) : "";
+        this.operationType = properties.containsKey(Attributes.TYPE)? properties.get(Attributes.TYPE) : "";
+        this.credentialsFile = properties.containsKey(Attributes.CREDENTIALS_FILE)? properties.get(Attributes.CREDENTIALS_FILE) : "";
     }
 
     @Override
@@ -69,5 +75,13 @@ public class DLink {
 
     public String getCalls() {
         return calls;
+    }
+    
+    public String getCredentialsFile() {
+        return credentialsFile;
+    }
+    
+    public String getOperationType() {
+        return operationType;
     }
 }

--- a/planner/aamwriter/src/main/resources/examples/atos_case_study.json
+++ b/planner/aamwriter/src/main/resources/examples/atos_case_study.json
@@ -12,13 +12,13 @@
                 "max_version": "8",
                 "qos": [
                     {
-                        "metric": "throughput",
-                        "operator": "LT",
+                        "metric": "AverageThroughput",
+                        "operator": "less_than",
                         "threshold": "10"
                     },
                     {
-                        "metric": "responsetime",
-                        "operator": "LT",
+                        "metric": "AverageResponseTime",
+                        "operator": "less_than",
                         "threshold": "5000"
                     }
                 ],
@@ -62,14 +62,18 @@
             "source": "www",
             "target": "webservices",
             "properties": {
-                "calls": "2"
+                "calls": "2",
+                "credentials_file": "",
+                "operation_type": "seaclouds.relation.connection.endpoint.host"
             }
         },
         {
             "source": "webservices",
             "target": "db1",
             "properties": {
-                "calls": "1"
+                "calls": "1",
+                "credentials_file": "",
+                "operation_type": "seaclouds.relations.databaseconnections.jdbc"
             }
         }
     ],

--- a/planner/aamwriter/src/main/resources/examples/atos_case_study_aam.yml
+++ b/planner/aamwriter/src/main/resources/examples/atos_case_study_aam.yml
@@ -1,22 +1,28 @@
 tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 description: Sample 3-tier application
 imports:
-- tosca-normative-types:1.0.0.wd03-SNAPSHOT
+- tosca-normative-types:1.0.0.wd06-SNAPSHOT
 topology_template:
   node_templates:
     www:
       type: sc_req.www
+      properties:
+        language: JAVA
       requirements:
       - endpoint: webservices
+        type: seaclouds.relation.connection.endpoint.host
     webservices:
       type: sc_req.webservices
       properties:
+        language: JAVA
+        location: ''
         java_version:
           constraints:
           - greater_or_equal: '7'
           - less_or_equal: '8'
       requirements:
       - endpoint: db1
+        type: seaclouds.relations.databaseconnections.jdbc
     db1:
       type: sc_req.db1
       properties:
@@ -82,6 +88,11 @@ groups:
           less_or_equal: 200.0 euros_per_month
         workload:
           less_or_equal: 50.0 req_per_min
+    - QoSRequirements:
+        AverageThroughput:
+          less_than: 10.0 req_per_min
+        AverageResponseTime:
+          less_than: 5000.0 ms
   operation_webservices:
     members:
     - webservices
@@ -96,3 +107,4 @@ groups:
     - db1
     policies:
     - dependencies: {}
+

--- a/planner/aamwriter/src/main/resources/examples/atos_case_study_aam.yml
+++ b/planner/aamwriter/src/main/resources/examples/atos_case_study_aam.yml
@@ -73,7 +73,7 @@ groups:
         benchmark_platform: hp_cloud_services.2xl
     - dependencies:
         operation_webservices: '2'
-    - QoSRequirements:
+    - AppQoSRequirements:
         response_time:
           less_than: 2000.0 ms
         availability:

--- a/planner/aamwriter/src/main/resources/examples/web-chat.json
+++ b/planner/aamwriter/src/main/resources/examples/web-chat.json
@@ -34,7 +34,9 @@
             "source": "Chat",
             "target": "MessageDatabase",
             "properties": {
-                "calls": "2"
+                "calls": "2",
+                "credentials_file": "",
+                "operation_type": "seaclouds.relations.databaseconnections.jdbc"
             }
         },
     ],

--- a/planner/aamwriter/src/main/resources/examples/web-chat_aam.yml
+++ b/planner/aamwriter/src/main/resources/examples/web-chat_aam.yml
@@ -1,16 +1,19 @@
 tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 description: WebChat application
 imports:
-- tosca-normative-types:1.0.0.wd03-SNAPSHOT
+- tosca-normative-types:1.0.0.wd06-SNAPSHOT
 topology_template:
   node_templates:
     Chat:
       type: sc_req.Chat
+      properties:
+        language: JAVA
       artifacts:
       - war: http://www.seaclouds.eu/artifacts/chat-webApplication.war
         type: tosca.artifacts.File
       requirements:
       - endpoint: MessageDatabase
+        type: seaclouds.relations.databaseconnections.jdbc
     MessageDatabase:
       type: sc_req.MessageDatabase
       artifacts:
@@ -56,7 +59,7 @@ groups:
         benchmark_platform: hp_cloud_services.2xl
     - dependencies:
         operation_MessageDatabase: '2'
-    - QoSRequirements:
+    - AppQoSRequirements:
         response_time:
           less_than: 2000.0 ms
         availability:
@@ -73,3 +76,4 @@ groups:
         execution_time: 30 ms
         benchmark_platform: hp_cloud_services.2xl
     - dependencies: {}
+

--- a/planner/aamwriter/src/test/resources/3tier.json
+++ b/planner/aamwriter/src/test/resources/3tier.json
@@ -66,8 +66,8 @@
             "source": "www",
             "target": "webservices",
             "properties": {
-                "calls": "2"
-                "operation_type": "seaclouds.relation.connection.endpoint.host",
+                "calls": "2",
+                "operation_type": "seaclouds.relation.connection.endpoint.host"
             }
         },
         {

--- a/planner/aamwriter/src/test/resources/3tier.json
+++ b/planner/aamwriter/src/test/resources/3tier.json
@@ -67,12 +67,15 @@
             "target": "webservices",
             "properties": {
                 "calls": "2"
+                "operation_type": "seaclouds.relation.connection.endpoint.host",
             }
         },
         {
             "source": "webservices",
             "target": "db1",
             "properties": {
+                "credentials_file": "db.props",
+                "operation_type": "seaclouds.relations.databaseconnections.jdbc",
                 "calls": "1"
             }
         }


### PR DESCRIPTION
This  PR defines relationships in a more-TOSCA way (still not TOSCA compliant: this needs also changes in the planner) and adds the needed changes in designer and aamwriter.

A relationship is now like:
```
requirements:
  - requirementName: targetNode
    type: relation_type
```

relation_type is one of the following: seaclouds.relations.databaseconnections.jdbc, seaclouds.relations.databaseconnections.php, seaclouds.relation.connection.endpoint.host


The designer now shows two more field in "edit link" form: 
* credentials_file: where to store the credentials in the deployed application
* type of relationship (relation_type above)

The aamwriter now writes the requirement in the form explained above and adds the credentials_file into the properties of the source node_template.

@kiuby88 : Can you review this?