### PR TITLE
Added InfluxDB + Grafana to the SeaClouds catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,18 @@ Make sure you have [Vagrant](https://www.vagrantup.com/), [Virtualbox](https://w
 
 ## Deploying SeaClouds on BYON
 
-### Deploying SeaClouds on the cloud
-
 - Configure your local environment:
 ```bash
 cd $SEACLOUDS_HOME/byon
 vagrant up
 ```
-This spins up a virtual environment, made up of 2 VMs `brooklyn` and `seaclouds1`, that are accessible at `10.10.10.100` and `10.10.10.101`, respectively.
+This spins up a virtual environment, made up of 2 VMs `brooklyn` and `seaclouds1`, that are accessible at `10.10.10.100` and `10.10.10.101`, respectively. 
+**Note that deploying on BYON requires at least 4 GB of RAM available and a quad-core CPU with hardware virtualization support.**
 
 - Point your favourite browser at `http://10.10.10.100:8081`
 - Select `SeaClouds Platform on BYON` application from Apache Brooklyn dropdown menu
 - Click on `Finish` button.
 
-### Deploying SeaClouds on BYON
 
 ## Deploying SeaClouds on the cloud
 

--- a/byon/files/seaclouds-catalog.bom
+++ b/byon/files/seaclouds-catalog.bom
@@ -63,6 +63,8 @@ brooklyn.catalog:
         sla.port: 1234
         monitor.manager.host: 127.0.0.1
         monitor.manager.port: 8170
+        monitor.grafana.host: 127.0.0.1
+        monitor.grafana.host: 3000
         planner.host: 127.0.0.1
         planner.port: 1234
 
@@ -75,6 +77,8 @@ brooklyn.catalog:
         SLA_PORT: $brooklyn:config("sla.port")
         MONITOR_HOST: $brooklyn:config("monitor.manager.host")
         MONITOR_PORT: $brooklyn:config("monitor.manager.port")
+        GRAFANA_HOST: $brooklyn:config("monitor.grafana.host")
+        GRAFANA_PORT: $brooklyn:config("monitor.grafana.host")
         PLANNER_HOST: $brooklyn:config("planner.host")
         PLANNER_PORT: $brooklyn:config("planner.port")
 
@@ -200,6 +204,109 @@ brooklyn.catalog:
 
       provisioning.properties:
         osFamily: ubuntu
+  - id: seaclouds-influxdb
+    name: InfluxDB
+    description: InfluxDB Server
+    item:
+      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+      id: influxdb
+      name: InfluxDB Server
+
+      brooklyn.config:
+        influxdb.port: 8086
+        influxdb.config.db.name: tower4clouds
+        influxdb.config.db.password: root
+
+      shell.env:
+        INFLUXDB_DB_NAME: $brooklyn:config("influxdb.config.db.name")
+        INFLUXDB_DB_USER: "root"
+        INFLUXDB_DB_PASSWORD: $brooklyn:config("influxdb.config.db.password")
+
+      provisioning.properties:
+        osFamily: ubuntu
+        required.ports:
+        - 22
+        - 8083
+        - 8086
+        - 8090
+        - 8099
+
+      install.command: |
+        sudo apt-get update -y
+        sudo apt-get install -y adduser libfontconfig wget
+        wget http://get.influxdb.org.s3.amazonaws.com/influxdb_0.8.9_amd64.deb
+        sudo dpkg -i influxdb_0.8.9_amd64.deb
+
+
+      customize.command: |
+        sudo service influxdb start
+        tee ./customize-influxdb.sh <<EOF
+        curl -X POST 'http://localhost:8086/cluster_admins/root?u=root&p=root' -d '{"password": "$INFLUXDB_DB_PASSWORD"}'
+        curl -X POST 'http://localhost:8086/db?u=$INFLUXDB_DB_USER&p=$INFLUXDB_DB_PASSWORD' -d '{"name": "$INFLUXDB_DB_NAME"}'
+        EOF
+        sleep 30s
+        sh customize-influxdb.sh
+        sudo service influxdb stop
+
+      launch.command: |
+        sudo service influxdb start
+        pidof influxdb > $PID_FILE
+
+      stop.command: |
+        sudo service influxdb stop
+  - id: seaclouds-grafana
+    name: Grafana Dashboard
+    description: Grafana Monitoring Dashboard
+    item:
+      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+      id: grafana
+      name: Grafana Server
+
+      brooklyn.config:
+        grafana.port: 3000
+        grafana.config.user: admin
+        grafana.config.password: admin
+        grafana.config.influxdb.url: http://localhost:8086
+        grafana.config.influxdb.db.name: tower4clouds
+        grafana.config.influxdb.db.password: root
+
+      shell.env:
+        GRAFANA_PORT: $brooklyn:config("grafana.port")
+        GRAFANA_USER: $brooklyn:config("grafana.config.user")
+        GRAFANA_PASSWORD: $brooklyn:config("grafana.config.password")
+        INFLUX_DB_URL: $brooklyn:config("grafana.config.influxdb.url")
+        INFLUXDB_DB_NAME: $brooklyn:config("grafana.config.influxdb.db.name")
+        INFLUXDB_DB_USER: "root"
+        INFLUXDB_DB_PASSWORD: $brooklyn:config("grafana.config.influxdb.db.password")
+
+      provisioning.properties:
+        osFamily: ubuntu
+        required.ports:
+        - 22
+        - 3000
+
+      install.command: |
+        sudo apt-get update -y
+        sudo apt-get install -y adduser libfontconfig wget
+        wget https://grafanarel.s3.amazonaws.com/builds/grafana_2.5.0_amd64.deb
+        sudo dpkg -i grafana_2.5.0_amd64.deb
+
+      customize.command: |
+        sudo service grafana-server start
+        tee ./customize-grafana.sh <<EOF
+        curl -H "Content-Type: application/json" -X PUT -d '{"oldPassword": "admin", "newPassword": "$GRAFANA_PASSWORD", "confirmNew": "$GRAFANA_PASSWORD"}' http://admin:admin@localhost:$GRAFANA_PORT/api/user/password
+        curl -H "Content-Type: application/json" -X POST -d '{"name": "InfluxDB", "url": "$INFLUX_DB_URL", "type": "influxdb_08", "database": "$INFLUXDB_DB_NAME", "user": "$INFLUXDB_DB_USER", "password":"$INFLUXDB_DB_PASSWORD", "access": "proxy", "isDefault": true}' http://$GRAFANA_USER:$GRAFANA_PASSWORD@localhost:$GRAFANA_PORT/api/datasources
+        EOF
+        sleep 30s
+        sh customize-grafana.sh
+        sudo service grafana-server stop
+
+      launch.command: |
+        sudo service grafana-server start
+        pidof grafana-server > $PID_FILE
+
+      stop.command: |
+        sudo service grafana-server stop
 
   - id: seaclouds-platform-on-byon
     name: "SeaClouds Platform on BYON"
@@ -228,6 +335,8 @@ brooklyn.catalog:
             sla.port: $brooklyn:component("sla-core").attributeWhenReady("http.port")
             monitor.manager.host: $brooklyn:component("monitor-manager").attributeWhenReady("host.address")
             monitor.manager.port: $brooklyn:component("monitor-manager").config("monitor.manager.port")
+            monitor.grafana.host: $brooklyn:component("grafana").attributeWhenReady("host.address")
+            monitor.grafana.port: $brooklyn:component("grafana").config("grafana.port")            
             planner.host: $brooklyn:component("planner").attributeWhenReady("host.address")
             planner.port: $brooklyn:component("planner").config("planner.config.port")
           launch.latch: $brooklyn:component("planner").attributeWhenReady("service.isUp")
@@ -264,6 +373,21 @@ brooklyn.catalog:
           install.latch: $brooklyn:component("monitor-dda").attributeWhenReady("service.isUp")
         - type: seaclouds-monitor-dda
           name: seaclouds-monitor-dda
+          install.latch: $brooklyn:component("grafana").attributeWhenReady("service.isUp")
+        - type: seaclouds-influxdb
+          name: seaclouds-influxdb
+          brooklyn.config:
+            influxdb.config.db.name: tower4clouds
+            influxdb.config.db.password: seaclouds
+        - type: seaclouds-grafana
+          name: seaclouds-grafana
+          brooklyn.config:
+            grafana.config.password: seaclouds
+            grafana.config.influxdb.url: $brooklyn:formatString("http://%s:%s", component("influxdb").attributeWhenReady("host.address"), component("influxdb").config("influxdb.port"))
+            grafana.config.influxdb.db.name: $brooklyn:component("influxdb").config("influxdb.config.db.name")
+            grafana.config.influxdb.db.password: $brooklyn:component("influxdb").config("influxdb.config.db.password")
+          install.latch: $brooklyn:component("influxdb").attributeWhenReady("service.isUp")
+
 
   - id: seaclouds-platform
     name: "SeaClouds Platform"
@@ -288,6 +412,8 @@ brooklyn.catalog:
           sla.port: $brooklyn:component("sla-core").attributeWhenReady("http.port")
           monitor.manager.host: $brooklyn:component("monitor-manager").attributeWhenReady("host.address")
           monitor.manager.port: $brooklyn:component("monitor-manager").config("monitor.manager.port")
+          monitor.grafana.host: $brooklyn:component("grafana").attributeWhenReady("host.address")
+          monitor.grafana.port: $brooklyn:component("grafana").config("grafana.port")            
           planner.host: $brooklyn:component("planner").attributeWhenReady("host.address")
           planner.port: $brooklyn:component("planner").config("planner.config.port")
         launch.latch: $brooklyn:component("planner").attributeWhenReady("service.isUp")
@@ -325,3 +451,15 @@ brooklyn.catalog:
         install.latch: $brooklyn:component("monitor-dda").attributeWhenReady("service.isUp")
       - type: seaclouds-monitor-dda
         name: seaclouds-monitor-dda
+      - type: seaclouds-influxdb
+        name: seaclouds-influxdb
+        brooklyn.config:
+          influxdb.config.db.name: tower4clouds
+          influxdb.config.db.password: seaclouds
+      - type: seaclouds-grafana
+        name: seaclouds-grafana
+        brooklyn.config:
+          grafana.config.password: seaclouds
+          grafana.config.influxdb.url: $brooklyn:formatString("http://%s:%s", component("influxdb").attributeWhenReady("host.address"), component("influxdb").config("influxdb.port"))
+          grafana.config.influxdb.db.name: $brooklyn:component("influxdb").config("influxdb.config.db.name")
+          grafana.config.influxdb.db.password: $brooklyn:component("influxdb").config("influxdb.config.db.password")

--- a/byon/servers.yaml
+++ b/byon/servers.yaml
@@ -1,8 +1,8 @@
 ---
 - name: brooklyn
   box: ubuntu/trusty64
-  ram: 2048
-  cpus: 4
+  ram: 1024
+  cpus: 1
   ip: 10.10.10.100
   forwarded_ports:
    - guest: 8081
@@ -19,7 +19,7 @@
     - nohup brooklyn-dist-0.9.0-SNAPSHOT/bin/brooklyn launch --catalogAdd /home/vagrant/.brooklyn/seaclouds-catalog.bom &
 - name: seaclouds1
   box: ubuntu/trusty64
-  ram: 1024
-  cpus: 2
+  ram: 3072
+  cpus: 4
   ip: 10.10.10.101
 ...

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -16,7 +16,7 @@ Running SeaClouds Dashboard only requires Java 7 (or greater) installed on the t
 - A config.yml configuration file.
 
 ### Config.yml configuration file
-SeaClouds Dashboard is packaged as a Dropwizard application. It requires a configuration file to run. This file contain the following user customizable parameters:
+SeaClouds Dashboard is packaged as a DropWizard application. It requires a configuration file to run. This file contain the following user customizable parameters:
 
 - server.connector.port: A positive number which will be used by Dropwizard to expose the Dashboard. Required. Eg. 8000.
 - planner.host: SeaClouds Planner IP. Required. Eg. 127.0.0.1.
@@ -27,6 +27,8 @@ SeaClouds Dashboard is packaged as a Dropwizard application. It requires a confi
 - deployer.password: SeaClouds Deployer Password. Optional. Eg. password.
 - monitor.manager.host: SeaClouds Monitor (Tower4Clouds Monitoring Manager) IP. Required. Eg. 127.0.0.1.
 - monitor.manager.port: SeaClouds Monitor (Tower4Clouds Monitoring Manager) Port. Required. Eg. 8710.
+- monitor.grafana.host: SeaClouds Monitor Dashboard (Grafana) IP. Required. Eg. 127.0.0.1.
+- monitor.grafana.port: SeaClouds Monitor Dashboard (Grafana) Port. Required. Eg. 3000.
 - sla.host: SeaClouds Deployer IP. Required. Eg. 127.0.0.1. 
 - sla.port: SeaClouds SLA Port. Required. Eg. 8080. 
 

--- a/dashboard/config.yml
+++ b/dashboard/config.yml
@@ -16,6 +16,9 @@ deployer:
 monitor.manager:
   host: ${MONITOR_HOST}
   port: ${MONITOR_PORT}
+monitor.grafana:
+  host: ${GRAFANA_HOST}
+  port: ${GRAFANA_PORT}
 sla:
   host: ${SLA_HOST}
   port: ${SLA_PORT}

--- a/dashboard/src/main/java/eu/seaclouds/platform/dashboard/DashboardApplication.java
+++ b/dashboard/src/main/java/eu/seaclouds/platform/dashboard/DashboardApplication.java
@@ -79,12 +79,12 @@ public class DashboardApplication extends Application<DashboardConfiguration> {
 
         // Configuring HealthChecks
         DashboardHealthCheck healthCheck = new DashboardHealthCheck(configuration.getDeployerProxy(),
-                configuration.getMonitorProxy(), configuration.getSlaProxy(), configuration.getPlannerProxy());
+                configuration.getMonitorProxy(), configuration.getGrafanaProxy(), configuration.getSlaProxy(), configuration.getPlannerProxy());
         environment.healthChecks().register(healthCheck.getName(), healthCheck);
 
         // Registering REST API Endpoints
         environment.jersey().register(new CoreResource(configuration.getDeployerProxy(),
-                configuration.getMonitorProxy(), configuration.getPlannerProxy(),
+                configuration.getMonitorProxy(), configuration.getGrafanaProxy(), configuration.getPlannerProxy(),
                 configuration.getSlaProxy()));
         environment.jersey().register(new DeployerResource(configuration.getDeployerProxy(), configuration.getMonitorProxy(), configuration.getSlaProxy(), configuration.getPlannerProxy()));
         environment.jersey().register(new MonitorResource(configuration.getMonitorProxy(), configuration.getDeployerProxy()));

--- a/dashboard/src/main/java/eu/seaclouds/platform/dashboard/DashboardConfiguration.java
+++ b/dashboard/src/main/java/eu/seaclouds/platform/dashboard/DashboardConfiguration.java
@@ -19,10 +19,7 @@ package eu.seaclouds.platform.dashboard;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import eu.seaclouds.platform.dashboard.proxy.DeployerProxy;
-import eu.seaclouds.platform.dashboard.proxy.MonitorProxy;
-import eu.seaclouds.platform.dashboard.proxy.PlannerProxy;
-import eu.seaclouds.platform.dashboard.proxy.SlaProxy;
+import eu.seaclouds.platform.dashboard.proxy.*;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
@@ -50,7 +47,11 @@ public class DashboardConfiguration extends Configuration {
     @Valid
     @NotNull
     private MonitorProxy monitor = new MonitorProxy();
-    
+
+    @Valid
+    @NotNull
+    private GrafanaProxy grafana;
+
     @Valid
     @NotNull
     private SlaProxy sla = new SlaProxy();
@@ -88,6 +89,16 @@ public class DashboardConfiguration extends Configuration {
     @JsonProperty("monitor.manager")
     public MonitorProxy getMonitorProxy() {
         return monitor;
+    }
+
+    @JsonProperty("monitor.grafana")
+    public void setGrafanaProxy(GrafanaProxy factory) {
+        grafana = factory;
+    }
+
+    @JsonProperty("monitor.grafana")
+    public GrafanaProxy getGrafanaProxy() {
+        return grafana;
     }
 
     @JsonProperty("monitor.manager")

--- a/dashboard/src/main/java/eu/seaclouds/platform/dashboard/DashboardHealthCheck.java
+++ b/dashboard/src/main/java/eu/seaclouds/platform/dashboard/DashboardHealthCheck.java
@@ -19,10 +19,7 @@ package eu.seaclouds.platform.dashboard;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheck.Result;
-import eu.seaclouds.platform.dashboard.proxy.DeployerProxy;
-import eu.seaclouds.platform.dashboard.proxy.MonitorProxy;
-import eu.seaclouds.platform.dashboard.proxy.PlannerProxy;
-import eu.seaclouds.platform.dashboard.proxy.SlaProxy;
+import eu.seaclouds.platform.dashboard.proxy.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +35,7 @@ public class DashboardHealthCheck extends HealthCheck {
     private final MonitorProxy monitor;
     private final SlaProxy sla;
     private final PlannerProxy planner;
+    private final GrafanaProxy grafana;
 
     private boolean portIsOpen(String ip, int port) {
         try (Socket socket = new Socket()) {
@@ -49,9 +47,10 @@ public class DashboardHealthCheck extends HealthCheck {
         }
     }
 
-    public DashboardHealthCheck(DeployerProxy deployer, MonitorProxy monitor, SlaProxy sla, PlannerProxy planner){
+    public DashboardHealthCheck(DeployerProxy deployer, MonitorProxy monitor, GrafanaProxy grafana, SlaProxy sla, PlannerProxy planner){
         this.deployer = deployer;
         this.monitor = monitor;
+        this.grafana = grafana;
         this.sla = sla;
         this.planner = planner;
     }
@@ -69,6 +68,10 @@ public class DashboardHealthCheck extends HealthCheck {
         }
 
         if(!portIsOpen(monitor.getHost(), monitor.getPort())){
+            return Result.unhealthy("The Monitor endpoint is not ready");
+        }
+
+        if(!portIsOpen(grafana.getHost(), grafana.getPort())){
             return Result.unhealthy("The Monitor endpoint is not ready");
         }
 

--- a/dashboard/src/main/java/eu/seaclouds/platform/dashboard/proxy/GrafanaProxy.java
+++ b/dashboard/src/main/java/eu/seaclouds/platform/dashboard/proxy/GrafanaProxy.java
@@ -15,21 +15,7 @@
  *      limitations under the License.
  */
 
-package eu.seaclouds.platform.dashboard.rest;
+package eu.seaclouds.platform.dashboard.proxy;
 
-import eu.seaclouds.platform.dashboard.proxy.GrafanaProxy;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertNotNull;
-
-public class CoreResourceTest extends AbstractResourceTest<CoreResource> {
-
-    private final CoreResource coreResource = new CoreResource(getDeployerProxy(), getMonitorProxy(), getGrafanaProxy(), getPlannerProxy(), getSlaProxy());
-
-    @Test
-    public void testGetSeaCloudsInformation() throws Exception {
-        assertNotNull(coreResource.getSeaCloudsInformation().getEntity());
-    }
-
-
+public class GrafanaProxy extends AbstractProxy {
 }

--- a/dashboard/src/main/java/eu/seaclouds/platform/dashboard/rest/CoreResource.java
+++ b/dashboard/src/main/java/eu/seaclouds/platform/dashboard/rest/CoreResource.java
@@ -21,10 +21,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.gson.JsonObject;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
-import eu.seaclouds.platform.dashboard.proxy.DeployerProxy;
-import eu.seaclouds.platform.dashboard.proxy.MonitorProxy;
-import eu.seaclouds.platform.dashboard.proxy.PlannerProxy;
-import eu.seaclouds.platform.dashboard.proxy.SlaProxy;
+import eu.seaclouds.platform.dashboard.proxy.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,12 +38,14 @@ public class CoreResource implements Resource{
 
     private final DeployerProxy deployerProxy;
     private final MonitorProxy monitorProxy;
+    private final GrafanaProxy grafanaProxy;
     private final PlannerProxy plannerProxy;
     private final SlaProxy slaProxy;
 
-    public CoreResource(DeployerProxy deployerProxy, MonitorProxy monitorProxy, PlannerProxy plannerProxy, SlaProxy slaProxy) {
+    public CoreResource(DeployerProxy deployerProxy, MonitorProxy monitorProxy, GrafanaProxy grafanaProxy, PlannerProxy plannerProxy, SlaProxy slaProxy) {
         this.deployerProxy = deployerProxy;
         this.monitorProxy = monitorProxy;
+        this.grafanaProxy = grafanaProxy;
         this.plannerProxy = plannerProxy;
         this.slaProxy = slaProxy;
     }
@@ -77,7 +76,12 @@ public class CoreResource implements Resource{
 
         JsonObject tower4CloudsObject = new JsonObject();
         tower4CloudsObject.addProperty("url", monitorProxy.getEndpoint());
+
+        JsonObject grafanaObject = new JsonObject();
+        grafanaObject.addProperty("url", grafanaProxy.getEndpoint());
+
         monitorObject.add("manager", tower4CloudsObject);
+        monitorObject.add("grafana", grafanaObject);
         jsonResponse.add("monitor", monitorObject);
 
         return Response.ok(jsonResponse.toString()).build();

--- a/dashboard/src/test/java/eu/seaclouds/platform/dashboard/rest/AbstractResourceTest.java
+++ b/dashboard/src/test/java/eu/seaclouds/platform/dashboard/rest/AbstractResourceTest.java
@@ -22,10 +22,7 @@ import eu.atos.sla.parser.data.Violation;
 import eu.atos.sla.parser.data.wsag.Agreement;
 import eu.atos.sla.parser.data.wsag.GuaranteeTerm;
 import eu.seaclouds.platform.dashboard.model.SeaCloudsApplicationDataStorage;
-import eu.seaclouds.platform.dashboard.proxy.DeployerProxy;
-import eu.seaclouds.platform.dashboard.proxy.MonitorProxy;
-import eu.seaclouds.platform.dashboard.proxy.PlannerProxy;
-import eu.seaclouds.platform.dashboard.proxy.SlaProxy;
+import eu.seaclouds.platform.dashboard.proxy.*;
 import eu.seaclouds.platform.dashboard.util.ObjectMapperHelpers;
 import eu.seaclouds.platform.dashboard.utils.TestFixtures;
 import eu.seaclouds.platform.dashboard.utils.TestUtils;
@@ -53,6 +50,7 @@ public abstract class AbstractResourceTest<T extends Resource> {
     protected static final String RANDOM_STRING = UUID.randomUUID().toString();
     private static final String DEPLOYER_ENDPOINT = "http://localhost:8081";
     private static final String MONITOR_ENDPOINT = "http://localhost:8170";
+    private static final String GRAFANA_ENDPOINT = "http://localhost:3000";
     private static final String PLANNER_ENDPOINT = "http://localhost:1234";
     private static final String SLA_ENDPOINT = "http://localhost:8080";
 
@@ -75,6 +73,7 @@ public abstract class AbstractResourceTest<T extends Resource> {
     private final MonitorProxy monitorProxy = mock(MonitorProxy.class);
     private final PlannerProxy plannerProxy = mock(PlannerProxy.class);
     private final SlaProxy slaProxy = mock(SlaProxy.class);
+    private final GrafanaProxy grafanaProxy = mock(GrafanaProxy.class);
 
     private void initObjects() throws IOException, JAXBException {
         applicationSummary = ObjectMapperHelpers.JsonToObject(
@@ -108,6 +107,7 @@ public abstract class AbstractResourceTest<T extends Resource> {
 
         when(deployerProxy.getEndpoint()).thenReturn(DEPLOYER_ENDPOINT);
         when(monitorProxy.getEndpoint()).thenReturn(MONITOR_ENDPOINT);
+        when(grafanaProxy.getEndpoint()).thenReturn(GRAFANA_ENDPOINT);
         when(plannerProxy.getEndpoint()).thenReturn(PLANNER_ENDPOINT);
         when(slaProxy.getEndpoint()).thenReturn(SLA_ENDPOINT);
 
@@ -206,6 +206,10 @@ public abstract class AbstractResourceTest<T extends Resource> {
 
     public MonitorProxy getMonitorProxy() {
         return monitorProxy;
+    }
+
+    public GrafanaProxy getGrafanaProxy(){
+        return grafanaProxy;
     }
 
     public PlannerProxy getPlannerProxy() {


### PR DESCRIPTION
With this PR InfluxDB and Grafana is installed when SeaClouds is deployed. This will ease the testing of an integrated workflow. Maybe the Monitor documentation should be updated to match the new setup with for example what the new config keys means (the Dashboard readme.md is updated properly) @MicheleGuerriero   WTDY?.

This PR is related with #206 and fixes #180 