### PR TITLE
Fixed wrong ADP nodes prefixes in the monitoring-dam-generator.

### DIFF
--- a/monitor/monitoring-dam-generator-core/resources/adp_example.yml
+++ b/monitor/monitoring-dam-generator-core/resources/adp_example.yml
@@ -32,19 +32,19 @@ topology_template:
       requirements:
       - {host: Amazon_EC2_i2_xlarge_us_west_2, instancesPOC: 1}
     Amazon_EC2_i2_xlarge_us_west_1:
-      type: seaclouds.Nodes.Compute.Amazon_EC2_i2_xlarge_us_west_1
+      type: seaclouds.nodes.Compute.Amazon_EC2_i2_xlarge_us_west_1
       properties: {resource_type: compute, hardwareId: i2.xlarge, location: 'aws:ec2',
         region: us-west-1, performance: 90, availability: 0.9995, country: United States,
         city: SAN JOSE, cost: 1.001 USD/hour, disk_size: 800, num_disks: 1, num_cpus: 4,
         ram: 30.5, disk_type: ssd}
     CloudFoundry:
-      type: seaclouds.Nodes.Platform.CloudFoundry_Pivotal
+      type: seaclouds.nodes.Platform.CloudFoundry_Pivotal
       properties: {resource_type: compute, hardwareId: m3.xlarge, location: 'aws:ec2',
         region: eu-central-1, performance: 90, availability: 0.9995, country: Germany,
         city: FRANKFURT, cost: 0.385 USD/hour, disk_size: 80, num_disks: 2, num_cpus: 4,
         ram: 15, disk_type: ssd}
     Amazon_EC2_i2_xlarge_us_west_2:
-      type: seaclouds.Nodes.Compute.Amazon_EC2_i2_xlarge_us_west_2
+      type: seaclouds.nodes.Compute.Amazon_EC2_i2_xlarge_us_west_2
       properties: {resource_type: compute, hardwareId: i2.xlarge, location: 'aws:ec2',
         region: us-west-2, performance: 90, availability: 0.9995, country: United States,
         city: PORTLAND, cost: 1.001 USD/hour, disk_size: 800, num_disks: 1, num_cpus: 4,

--- a/monitor/monitoring-dam-generator-core/src/main/java/eu/seaclouds/monitor/monitoringdamgenerator/adpparsing/YAMLMonitorParser.java
+++ b/monitor/monitoring-dam-generator-core/src/main/java/eu/seaclouds/monitor/monitoringdamgenerator/adpparsing/YAMLMonitorParser.java
@@ -17,8 +17,8 @@ public class YAMLMonitorParser {
     private static Logger logger = LoggerFactory
             .getLogger(YAMLMonitorParser.class);
 
-    public static final String COMPUTE_NODE_PREFIX = "seaclouds.Nodes.Compute";
-    public static final String PLATFORM_NODE_PREFIX = "seaclouds.Nodes.Platform";
+    public static final String COMPUTE_NODE_PREFIX = "seaclouds.nodes.Compute";
+    public static final String PLATFORM_NODE_PREFIX = "seaclouds.nodes.Platform";
     public static final String QOS_REQUIREMENT_POLICY = "QoSRequirements";
     public static final String RESPONSE_TIME_REQUIREMENT = "response_time";
     public static final String AVAILABILITY_REQUIREMENT = "availability";

--- a/monitor/monitoring-dam-generator-core/src/test/java/eu/seaclouds/monitor/monitoringdamgenerator/MonitoringGenerationTest.java
+++ b/monitor/monitoring-dam-generator-core/src/test/java/eu/seaclouds/monitor/monitoringdamgenerator/MonitoringGenerationTest.java
@@ -31,7 +31,7 @@ public class MonitoringGenerationTest {
         MonitoringDamGenerator service = new MonitoringDamGenerator(new URL("http://127.0.0.1:8170"), new URL("http://127.0.0.1:8083"));
 
         MonitoringInfo returned = service
-                .generateMonitoringInfo(readFile("resources/currentAtosAdpFromOptimizer.yml",
+                .generateMonitoringInfo(readFile("resources/adp_example.yml",
                         Charset.defaultCharset()));
 
         parametersTest = new HashMap<String, String>();

--- a/monitor/monitoring-dam-generator-core/src/test/java/eu/seaclouds/monitor/monitoringdamgenerator/adpparsing/AdpParsingTest.java
+++ b/monitor/monitoring-dam-generator-core/src/test/java/eu/seaclouds/monitor/monitoringdamgenerator/adpparsing/AdpParsingTest.java
@@ -20,7 +20,7 @@ public class AdpParsingTest {
     public void parsingTest() throws Exception {
         
         YAMLMonitorParser adpParser = new YAMLMonitorParser();
-        byte[] encoded = Files.readAllBytes(Paths.get("resources/currentAtosAdpFromOptimizer.yml"));
+        byte[] encoded = Files.readAllBytes(Paths.get("resources/adp_example.yml"));
 
         List<Module> modules = adpParser.getModuleRelevantInfoFromAdp(new String(encoded, Charset.defaultCharset()));
 

--- a/planner/core/src/test/resources/generated_adp.yml
+++ b/planner/core/src/test/resources/generated_adp.yml
@@ -31,12 +31,12 @@ topology_template:
       requirements:
       - {instancesPOC: 8, host: App42_PaaS_America_US}
     Vultr_64gb_mc_atlanta:
-      type: seaclouds.Nodes.Compute
+      type: seaclouds.nodes.Compute
       properties: {num_cpus: 24, country: United States, cost: 0.893 USD/hour, hardwareId: 64gb-mc,
         city: ATLANTA, disk_type: ssd, resource_type: compute, disk_size: 800, location: 'vultr:compute',
         region: atlanta, ram: 64}
     App42_PaaS_America_US:
-      type: seaclouds.Nodes.Platform
+      type: seaclouds.nodes.Platform
       properties: {continent: America, country: US, postgresql_support: true, php_version: 5.5,
         auto_scaling: false, postgresql_version: 9.1, horizontal_scaling: true, python_version: 2.7,
         vertical_scaling: true, php_support: true, node_support: true, tomcat_version: 6.0,
@@ -45,7 +45,7 @@ topology_template:
         redis_support: true, mysql_version: 5.5, java_support: true, redis_version: 2.8,
         ruby_support: true, python_support: true, java_version: 7, mysql_support: true}
     Rapidcloud_io_Asia_HK:
-      type: seaclouds.Nodes.Platform
+      type: seaclouds.nodes.Platform
       properties: {continent: Asia, country: HK, tomcat_version: 8.0, private_hosting: false,
         resource_type: platform, tomcat_support: true, auto_scaling: false, public_hosting: true,
         memcached_support: true, redis_support: true, mysql_version: 5.6, java_support: true,


### PR DESCRIPTION
This PR fixes an issue in the monitor-dam-generator related to node templates in the ADP of type seaclouds.node.Compute or seaclouds.node.Platform that was previously defined to be seaclouds.Node.Compute, sea clouds.Node.Platform. The fix is applied also in the resources used by the planner for its tests.
@PaoloCifariello can you have a look at this?