### PR TITLE
FEATURE(credentials): Add credentials forms and credentials storage according to provider.

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/credentials-view.html
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/credentials-view.html
@@ -16,15 +16,17 @@
                 </div>
                 <div class="modal-body">
                     <form role="form">
-                        <fieldset id="set-apikey">
-                            <legend>API Key <a href="#"><i class="fa fa-chevron-down"> </i></a></legend>
+                        <fieldset id="set-amazon">
                             <div class="form-group">
-                                <label for="apikey-apikey">API Key</label>
-                                <input type="text" class="form-control" id="apikey-apikey">
+                                <label for="amazon-identity">Identity</label>
+                                <input type="text" class="form-control" id="amazon-identity">
+                            </div>
+                            <div class="form-group">
+                                <label for="amazon-credential">Credential</label>
+                                <input type="text" class="form-control" id="amazon-credential">
                             </div>
                         </fieldset>
                         <fieldset id="set-userpwd">
-                            <legend>User/Password<a href="#"><i class="fa fa-chevron-down"> </i></a></legend>
                             <div class="form-group">
                                 <label for="user">User</label>
                                 <input type="text" class="form-control" id="userpwd-user">
@@ -32,6 +34,30 @@
                             <div class="form-group">
                                 <label for="user">Password</label>
                                 <input type="text" class="form-control" id="userpwd-pwd">
+                            </div>
+                        </fieldset>
+                        <fieldset id="set-cloudfoundry">
+                            <div class="form-group">
+                                <label for="cloudfoundry-org">Organization</label>
+                                <input type="text" class="form-control" id="cloudfoundry-org">
+                            </div>
+                            <div class="form-group">
+                                <label for="cloudfoundry-space">Space</label>
+                                <input type="text" class="form-control" id="cloudfoundry-space">
+                            </div>
+                            <div class="form-group">
+                                <label for="cloudfoundry-address">Platform address</label>
+                                <input type="text" class="form-control" id="cloudfoundry-space">
+                            </div>
+                            <div class="form-group">
+                                <label for="cloudfoundry-endpoint">API endpoint</label>
+                                <input type="text" class="form-control" id="cloudfoundry-endpoint">
+                            </div>
+                        </fieldset>
+                        <fieldset id="set-generic">
+                            <div class="form-group">
+                                <label for="generic-value">API Key</label>
+                                <input type="text" class="form-control" id="generic-value">
                             </div>
                         </fieldset>
                     </form>

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/types.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/types.js
@@ -101,12 +101,6 @@ var Types = function() {
         label : "Cloud",
         type : "Cloud",
         icon : "\uf0c2",
-        identity : function() {
-            return this.properties.apikey || this.properties.user || "";
-        },
-        credential: function() {
-            return this.properties.password || "";
-        }
     });
 
     var Module = Object.create(Graph.Node).init({


### PR DESCRIPTION
This PR adds forms to enter the credentials for amazon, openshift and cloudfoundry. Another generic form (to simply type key/values separated by ';') is implemented in case the provider is not recognized. The credentials are stored in the brooklyn_location policy according the properties defined in section 7.2.2 of DAM model

It is important that the location property of the node_template related to the provider matches the variable ```form_by_provider``` (credential.js:23). I would need @kiuby88 and @jacopogiallo to check this.

@adriannieto : Could you check the PR? Thanks
