### PR TITLE
FEATURE(aamwriter): Handles property application_requirements/frontend

### DIFF
--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
@@ -239,9 +239,9 @@ public class Translator {
             sourceOperation.addDependencies(new Policy.Dependencies(dependencies));
             
             /*
-             * Application QosRequirements if this node is the source of the flow graph
+             * Application QosRequirements if this node is the frontend
              */
-            if (isSource(dgraph, dnode)) {
+            if (dnode.isFrontend()) {
                 DRequirements dreq = dgraph.getRequirements();
                 Policy.AppQoSRequirements requirements = new Policy.AppQoSRequirements(
                         dreq.getResponseTime(), dreq.getAvailability(), dreq.getCost(), dreq.getWorkload());
@@ -297,11 +297,6 @@ public class Translator {
         return artifactName;
     }
     
-    private boolean isSource(DGraph dgraph, DNode dnode) {
-        List<DLink> links = dgraph.getLinksTo(dnode);
-        return links.size() == 0;
-    }
-
     private String buildOperationName(DNode dnode) {
         return OPERATION_PREFIX + dnode.getName();
     }

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DLink.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DLink.java
@@ -21,6 +21,11 @@ import java.util.Map;
 
 import org.json.simple.JSONObject;
 
+/**
+ * Classes in aamwriter.modeldesigner package model the topology described in UI. 
+ * 
+ * DLink class models a "uses" relationship between two DNodes.
+ */
 public class DLink {
 
     public static final class Attributes {

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DNode.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DNode.java
@@ -23,6 +23,12 @@ import java.util.Map;
 
 import org.json.simple.JSONObject;
 
+/**
+ * Classes in aamwriter.modeldesigner package model the topology described in UI. 
+ * 
+ * DNode class models a module in the topology, describing the name, tech properties,
+ * deployment properties and needed QoS.
+ */
 public class DNode {
     public static final class Attributes {
         public static final String NAME = "name";
@@ -200,5 +206,13 @@ public class DNode {
     
     public List<Map<String, String>> getQos() {
         return qos;
+    }
+    
+    public boolean isFrontend() {
+        boolean result = false;
+        if (this.graph != null) {
+            result = (this.graph.getFrontendNode() == this);
+        }
+        return result;
     }
 }

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DRequirements.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DRequirements.java
@@ -18,6 +18,11 @@ package eu.seaclouds.platform.planner.aamwriter.modeldesigner;
 
 import org.json.simple.JSONObject;
 
+/**
+ * Classes in aamwriter.modeldesigner package model the topology described in UI. 
+ * 
+ * DRequirements class stores QoS needed for the whole application.
+ */
 public class DRequirements {
 
     public static final class Attributes {
@@ -25,6 +30,7 @@ public class DRequirements {
         public static final String AVAILABILITY = "availability";
         public static final String COST = "cost";
         public static final String WORKLOAD = "workload";
+        public static final String FRONTEND = "frontend";
     }
     
     @SuppressWarnings("unused")
@@ -34,6 +40,7 @@ public class DRequirements {
     private double availability;
     private double cost;
     private double workload;
+    private String frontendModuleName;
 
     public DRequirements(JSONObject jnode, DGraph graph) {
         this.graph = graph;
@@ -42,11 +49,20 @@ public class DRequirements {
         this.availability = parseDouble(jnode, Attributes.AVAILABILITY);
         this.cost = parseDouble(jnode, Attributes.COST);
         this.workload = parseDouble(jnode, Attributes.WORKLOAD);
+        this.frontendModuleName = parseString(jnode, Attributes.FRONTEND);
     }
     
     private double parseDouble(JSONObject jnode, String key) {
-        double result = Double.parseDouble(jnode.get(key).toString());
+        Object value = jnode.get(key);
+        double result = (value == null)? 0: Double.parseDouble(value.toString());
         
+        return result;
+    }
+    
+    private String parseString(JSONObject jnode, String key) {
+        Object value = jnode.get(key);
+        
+        String result = (value == null)? "" : value.toString();
         return result;
     }
 
@@ -70,5 +86,9 @@ public class DRequirements {
     
     public double getWorkload() {
         return workload;
+    }
+    
+    public String getFrontend() {
+        return frontendModuleName;
     }
 }

--- a/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/DesignerModelTest.java
+++ b/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/DesignerModelTest.java
@@ -17,7 +17,6 @@
 package eu.seaclouds.platform.planner.aamwriter;
 
 import org.json.simple.JSONObject;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -27,19 +26,15 @@ import eu.seaclouds.platform.planner.aamwriter.modeldesigner.DNode;
 
 public class DesignerModelTest {
 
-    private static final DNode[] EMPTY_NODES = {};
-    private static final DLink[] EMPTY_LINKS = {};
-    private static JSONObject root;
-    private static DGraph graph;
-
-    @BeforeClass
-    private static void beforeClass() throws Exception {
-        root = (JSONObject) TestUtils.loadJson("/3tier.json");
-        graph = new DGraph(root);
-    }
+    private final DNode[] EMPTY_NODES = {};
+    private final DLink[] EMPTY_LINKS = {};
+    private JSONObject root;
+    private DGraph graph;
 
     @Test
-    public void testLoadGraph() {
+    public void testLoadGraph() throws Exception {
+        root = (JSONObject) TestUtils.loadJson("/3tier.json");
+        graph = new DGraph(root);
 
         graph = new DGraph(root);
         assertNotNull(graph);
@@ -63,4 +58,35 @@ public class DesignerModelTest {
         assertEquals(links[1].getTarget(), nodes[2]);
     }
 
+    @Test
+    public void testFrontendNodeIsEmpty() throws Exception {
+        root = (JSONObject) TestUtils.loadJson("/3tier.json");
+        graph = new DGraph(root);
+        
+        assertEquals(graph.getFrontendNode().getName(), "www");
+        assertTrue(graph.getNode("www").isFrontend());
+        assertFalse(graph.getNode("db1").isFrontend());
+        
+    }
+
+    @Test
+    public void testFrontendNodeIsFilled() throws Exception {
+        root = (JSONObject) TestUtils.loadJson("/frontend.json");
+        graph = new DGraph(root);
+        
+        assertEquals(graph.getFrontendNode().getName(), "webservices");
+        assertFalse(graph.getNode("www").isFrontend());
+        assertTrue(graph.getNode("webservices").isFrontend());
+    }
+    
+    @Test
+    public void testWrontFrontendName() throws Exception {
+        root = (JSONObject) TestUtils.loadJson("/wrong_frontend.json");
+        graph = new DGraph(root);
+        
+        assertEquals(graph.getFrontendNode().getName(), "www");
+        assertFalse(graph.getNode("webservices").isFrontend());
+        assertTrue(graph.getNode("www").isFrontend());
+        assertFalse(graph.getNode("db1").isFrontend());
+    }
 }

--- a/planner/aamwriter/src/test/resources/frontend.json
+++ b/planner/aamwriter/src/test/resources/frontend.json
@@ -1,0 +1,52 @@
+{
+    "name": "3tier example",
+    "nodes": [
+        {
+            "name": "www",
+            "label": "www",
+            "type": "WebApplication",
+            "properties": {
+            }
+        },
+        {
+            "name": "webservices",
+            "label": "webservices",
+            "type": "WebApplication",
+            "properties": {
+            }
+        },
+        {
+            "name": "db1",
+            "label": "db1",
+            "type": "Database",
+            "properties": {
+            }
+        }
+    ],
+    "links": [
+        {
+            "source": "www",
+            "target": "webservices",
+            "properties": {
+                "calls": "2",
+                "operation_type": "seaclouds.relation.connection.endpoint.host"
+            }
+        },
+        {
+            "source": "webservices",
+            "target": "db1",
+            "properties": {
+                "credentials_file": "db.props",
+                "operation_type": "seaclouds.relations.databaseconnections.jdbc",
+                "calls": "1"
+            }
+        }
+    ],
+    "application_requirements": {
+        "response_time": "2000",
+        "availability": 0.98,
+        "cost": "200",
+        "workload": "50",
+        "frontend": "webservices"
+    }
+}

--- a/planner/aamwriter/src/test/resources/wrong_frontend.json
+++ b/planner/aamwriter/src/test/resources/wrong_frontend.json
@@ -1,0 +1,52 @@
+{
+    "name": "3tier example",
+    "nodes": [
+        {
+            "name": "www",
+            "label": "www",
+            "type": "WebApplication",
+            "properties": {
+            }
+        },
+        {
+            "name": "webservices",
+            "label": "webservices",
+            "type": "WebApplication",
+            "properties": {
+            }
+        },
+        {
+            "name": "db1",
+            "label": "db1",
+            "type": "Database",
+            "properties": {
+            }
+        }
+    ],
+    "links": [
+        {
+            "source": "www",
+            "target": "webservices",
+            "properties": {
+                "calls": "2",
+                "operation_type": "seaclouds.relation.connection.endpoint.host"
+            }
+        },
+        {
+            "source": "webservices",
+            "target": "db1",
+            "properties": {
+                "credentials_file": "db.props",
+                "operation_type": "seaclouds.relations.databaseconnections.jdbc",
+                "calls": "1"
+            }
+        }
+    ],
+    "application_requirements": {
+        "response_time": "2000",
+        "availability": 0.98,
+        "cost": "200",
+        "workload": "50",
+        "frontend": "noexiste"
+    }
+}


### PR DESCRIPTION
This PR allows the specification of a frontend module in application_requirements/frontend element. Before this, the frontend module is calculated as the source node of the flow graph.

If the frontend (the node "visible" to the users, to which we want to apply the QoS requirements) is not the source of the node graph (assume a test module that connects to the frontend), the frontend must be specified.

Example:

```
{
    "nodes": [ ... ],
    "links": [ ... ],
    "application_requirements": {
        "response_time": "2000",
        "availability": 0.98,
        "cost": "200",
        "workload": "50",
        "frontend": "www"
    }
}
```