### PR TITLE
Remove duplicate ADPs. Solving issue #240

### DIFF
--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
@@ -108,9 +108,9 @@ public class OptimizerInitialDeployment {
          int numPlansToGenerate, double hyst) {
 
       log.debug("Optimization method started. Inputs received");
-      log.debug("AAM is: " + appModel);
-      log.debug("Suitable offers are: " + suitableCloudOffer);
-      log.debug("Informaton of Benchmark platform is: " + benchmarkPlatformsYaml);
+      log.trace("AAM is: {}", appModel);
+      log.trace("Suitable offers are: {} ", suitableCloudOffer);
+      log.trace("Informaton of Benchmark platform is: {}" , benchmarkPlatformsYaml);
 
       // Get app characteristics
       Map<String, Object> appMap = YAMLoptimizerParser.getMAPofAPP(appModel);
@@ -157,7 +157,7 @@ public class OptimizerInitialDeployment {
       // inside
 
       // Compute solution
-      Solution[] solutions = engine.computeOptimizationProblem(appInfoSuitableOptions.clone(), requirements, topology,
+      Solution[] solutions = engine.computeOptimizationProblemForAllDifferentSolutions(appInfoSuitableOptions.clone(), requirements, topology,
             numPlansToGenerate);
 
       if (solutions == null) {
@@ -165,15 +165,16 @@ public class OptimizerInitialDeployment {
       }
 
       Map<String, Object>[] appMapSolutions = hashMapOfFoundSolutionsWithThresholds(solutions, appMap, topology,
-            appInfoSuitableOptions, numPlansToGenerate, requirements, suitableCloudOffer, hyst);
+            appInfoSuitableOptions, requirements, suitableCloudOffer, hyst);
 
       log.debug("Before ReplaceSuitableServiceByHost and adding the seaclouds.nodes.Compute type information");
 
-      String[] stringSolutions = new String[numPlansToGenerate];
+      String[] stringSolutions = new String[appMapSolutions.length];
       for (int i = 0; i < appMapSolutions.length; i++) {
          YAMLoptimizerParser.addComputeTypeToTypes(appMapSolutions[i]);
          YAMLoptimizerParser.replaceSuitableServiceByHost(appMapSolutions[i]);
          stringSolutions[i] = YAMLoptimizerParser.fromMAPtoYAMLstring(appMapSolutions[i]);
+         log.debug("Compute type addition finished for solution index {}", i);
       }
 
       return stringSolutions;
@@ -195,14 +196,14 @@ public class OptimizerInitialDeployment {
    }
 
    private Map<String, Object>[] hashMapOfFoundSolutionsWithThresholds(Solution[] bestSols,
-         Map<String, Object> applicMap, Topology topology, SuitableOptions cloudOffers, int numPlansToGenerate,
+         Map<String, Object> applicMap, Topology topology, SuitableOptions cloudOffers, 
          QualityInformation requirements, String suitableCloudOffer, double hyst) {
 
       if (log.isDebugEnabled()) {
          engine.checkQualityAttachedToSolutions(bestSols);
       }
       @SuppressWarnings("unchecked")
-      Map<String, Object>[] solutions = new HashMap[numPlansToGenerate];
+      Map<String, Object>[] solutions = new HashMap[bestSols.length];
 
       for (int i = 0; i < bestSols.length; i++) {
 
@@ -357,18 +358,12 @@ public class OptimizerInitialDeployment {
       double perfGoodness = requirements.getResponseTime() / qualityAnalyzer
             .computePerformance(sol, topology, requirements.getWorkload(), cloudCharacteristics).getResponseTime();
 
-      log.debug("Create reconfiguration Thresholds method has finished its call to compute Performance");
+      log.debug("Create reconfiguration Thresholds method has finished its call to compute Performance with result {}", perfGoodness);
 
-      if ((requirements.existResponseTimeRequirement()) && (perfGoodness >= 1.0)) {// response
-         // time
-         // requirements
-         // are
-         // satisfied
-         // if
-         // perfGoodness>=1.0
+      if ((requirements.existResponseTimeRequirement()) && (perfGoodness >= 1.0)) {
+         // response time requirements are satisfied if perfGoodness>=1.0
 
-         // A HashMap with all the keys of module names, and associated an
-         // arraylist with the thresholds for reconfigurations.
+         // A HashMap with all the keys of module names, and associated an arraylist with the thresholds for reconfigurations.
          HashMap<String, ArrayList<Double>> thresholds = new HashMap<String, ArrayList<Double>>();
 
          log.debug("Starting teh computation of reconfiguration thresholds");

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/Solution.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/Solution.java
@@ -101,7 +101,7 @@ public class Solution implements Iterable<String>, Comparable<Solution> {
    public void modifyNumInstancesOfModule(String modulename, int newInstances) {
 
       if (!modName_NumInstances.containsKey(modulename)) {
-         log.error("trying to modify the number of instances of a module which does not exist");
+         log.error("trying to modify the number of instances of a module which does not exist. The name of the module searched was {}", modulename);
       } else {
          modName_NumInstances.put(modulename, newInstances);
       }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/AbstractHeuristic.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/AbstractHeuristic.java
@@ -34,9 +34,9 @@ public abstract class AbstractHeuristic {
 
    static Logger log = LoggerFactory.getLogger(AbstractHeuristic.class);
 
-   private int MAX_ITER_NO_IMPROVE = 200; // 200;
-   private double MAX_TIMES_IMPROVE_REQUIREMENT = 20;
-   private static final int DEFAULT_MAX_NUM_INSTANCES = 10;
+   private int MAX_ITER_NO_IMPROVE = 200;
+   private double           MAX_TIMES_IMPROVE_REQUIREMENT = 20;
+   private static final int DEFAULT_MAX_NUM_INSTANCES     = 10;
 
    public AbstractHeuristic(int maxIter) {
       MAX_ITER_NO_IMPROVE = maxIter;
@@ -450,6 +450,40 @@ public abstract class AbstractHeuristic {
 
       }
 
+   }
+
+   protected Solution[] filterUniqueSolutions(Solution[] sols) {
+      int duplicatedElements = 0;
+
+      // remove one by one from sols and check whether sols still contains the
+      // removed one.
+      for (int i = 0; i < sols.length; i++) {
+         Solution current = sols[i];
+         sols[i] = null;
+
+         if (current.isContainedIn(sols)) {
+            duplicatedElements++;
+         } else {
+            sols[i] = current;
+         }
+      }
+
+      // now sols[] contains only different solutions and null values. Remove
+      // the nulls.
+      Solution[] newSols = new Solution[sols.length - duplicatedElements];
+      int newSolsIndex = 0;
+      for (int i = 0; i < sols.length; i++) {
+         if (sols[i] != null) {
+            newSols[newSolsIndex] = sols[i];
+            newSolsIndex++;
+         }
+      }
+      if (newSolsIndex != newSols.length) {
+         log.warn(
+               "Something weird happened removing duplicated solutions: the number of different solutions were {} but they are only returned {}",
+               newSols.length, newSolsIndex);
+      }
+      return newSols;
    }
 
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/Anneal.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/Anneal.java
@@ -41,6 +41,13 @@ public class Anneal extends AbstractHeuristic implements SearchMethod {
    public Anneal() {
    }
 
+   
+   @Override
+   public Solution[] computeOptimizationProblemForAllDifferentSolutions(SuitableOptions cloudOffers, QualityInformation requirements,
+         Topology topology, int numPlansToGenerate) {
+      return super.filterUniqueSolutions(computeOptimizationProblem(cloudOffers,requirements,topology,numPlansToGenerate));
+   }
+   
    @Override
    public Solution[] computeOptimizationProblem(SuitableOptions cloudOffers, QualityInformation requirements,
          Topology topology, int numPlansToGenerate) {

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/BlindSearch.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/BlindSearch.java
@@ -33,6 +33,14 @@ public class BlindSearch extends AbstractHeuristic implements SearchMethod {
    public BlindSearch(int maxIter) {
       super(maxIter);
    }
+   
+   
+   
+   @Override
+   public Solution[] computeOptimizationProblemForAllDifferentSolutions(SuitableOptions cloudOffers, QualityInformation requirements,
+         Topology topology, int numPlansToGenerate) {
+      return super.filterUniqueSolutions(computeOptimizationProblem(cloudOffers,requirements,topology,numPlansToGenerate));
+   }
 
    /*
     * (non-Javadoc)

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/HillClimb.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/HillClimb.java
@@ -40,6 +40,15 @@ public class HillClimb extends AbstractHeuristic implements SearchMethod {
    public HillClimb(int maxIter) {
       super(maxIter);
    }
+   
+   
+   
+   
+   @Override
+   public Solution[] computeOptimizationProblemForAllDifferentSolutions(SuitableOptions cloudOffers, QualityInformation requirements,
+         Topology topology, int numPlansToGenerate) {
+      return super.filterUniqueSolutions(computeOptimizationProblem(cloudOffers,requirements,topology,numPlansToGenerate));
+   }
 
    /*
     * (non-Javadoc)

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/SearchMethod.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/SearchMethod.java
@@ -35,9 +35,14 @@ public interface SearchMethod {
     * @return
     */
    
+   public Solution[] computeOptimizationProblemForAllDifferentSolutions(
+         SuitableOptions cloudOffers, QualityInformation requirements,
+         Topology topology, int numPlansToGenerate);
+   
    public Solution[] computeOptimizationProblem(
          SuitableOptions cloudOffers, QualityInformation requirements,
          Topology topology, int numPlansToGenerate);
+   
    
    public void checkQualityAttachedToSolutions(Solution[] solutions);
 

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
@@ -546,6 +546,10 @@ public class QualityAnalyzer {
 
    private void addResourceToSolution(Solution sol, String moduleWithHighestUtilization) {
 
+      if (moduleWithHighestUtilization == null) {
+         return;
+      }
+
       try {
          sol.modifyNumInstancesOfModule(moduleWithHighestUtilization,
                sol.getCloudInstancesForModule(moduleWithHighestUtilization) + 1);

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
@@ -708,6 +708,7 @@ public class YAMLoptimizerParser {
 
       } catch (NullPointerException E) {
          log.error("It was not found '" + TOSCAkeywords.NODE_TYPES + "' . Cannot be unveiled the types of modules");
+         log.error(TOSCAkeywords.NODE_TYPES + " was searched in " + YAMLoptimizerParser.fromMAPtoYAMLstring(appMap));
          return null;
       }
       return typesMap;

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/AbstractTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/AbstractTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import org.slf4j.Logger;
 
 import eu.seaclouds.platform.planner.optimizer.Optimizer;
+import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
 
 public class AbstractTest {
 
@@ -50,6 +51,26 @@ public class AbstractTest {
 
       try {
          suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
+      } catch (IOException e) {
+         log.error("File for Cloud Offers not found");
+         e.printStackTrace();
+      }
+      
+   }
+   
+   public void openInputFiles(String appmodel, String cloudOffers) {
+      final String dir = System.getProperty("user.dir");
+      log.debug("Trying to open files: current executino dir = " + dir);
+
+      try {
+         appModel = filenameToString(appmodel);
+      } catch (IOException e) {
+         log.error("File for APPmodel not found");
+         e.printStackTrace();
+      }
+
+      try {
+         suitableCloudOffer = filenameToString(cloudOffers);
       } catch (IOException e) {
          log.error("File for Cloud Offers not found");
          e.printStackTrace();
@@ -83,6 +104,8 @@ public class AbstractTest {
       }
 
    }
+
+
    
    
 }

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015UniqueSolutionsTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015UniqueSolutionsTest.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2015 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package eu.seaclouds.platform.planner.optimizerTest;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import eu.seaclouds.platform.planner.optimizer.Optimizer;
+import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
+import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser;
+
+public class OptimizerTOSCADecember2015UniqueSolutionsTest extends AbstractTest {
+
+   @BeforeClass
+   public void createObjects() {
+
+      log = LoggerFactory.getLogger(OptimizerTOSCADecember2015UniqueSolutionsTest.class);
+
+      log.info("Starting TEST optimizer for the TOSCA syntax of September 2015");
+      openInputFiles(TestConstants.APP_MODEL_FILENAME_SINGLE_MODULE,
+            TestConstants.CLOUD_OFFER_FILENAME_IN_JSON_SINGLE_OFFER);
+   }
+
+   @Test(enabled = true)
+   public void testExecutePassingUniqueOptionToBlind() {
+
+      log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer SINGLE ADP - STARTED (syntax December 2015)===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.BLINDSEARCH);
+
+      executeAndSave(appModel, suitableCloudOffer, SearchMethodName.BLINDSEARCH);
+
+      log.info("=== TEST for SOLUTION GENERATION with POLICIES of BLIND optimizer SINGLE ADP - FINISEHD ===");
+
+   }
+
+   @Test(enabled = true)
+   public void testExecutePassingUniqueOptionToHillClimb() {
+
+      log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer SINGLE ADP - STARTED ===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.HILLCLIMB);
+
+      executeAndSave(appModel, suitableCloudOffer, SearchMethodName.HILLCLIMB);
+
+      log.info("=== TEST for SOLUTION GENERATION with POLICIES of HILLCLIMB optimizer SINGLE ADP FINISEHD ===");
+
+   }
+
+   @Test(enabled = true)
+   public void testExecutePassingUniqueOptionToAnneal() {
+
+      log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer SINGLE ADP - STARTED ===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.ANNEAL);
+
+      executeAndSave(appModel, suitableCloudOffer, SearchMethodName.ANNEAL);
+
+      log.info("=== TEST for SOLUTION GENERATION with POLICIES of ANNEAL optimizer SINGLE ADP - FINISEHD ===");
+
+   }
+
+   public void executeAndSave(String appModel2, String suitableCloudOffer2, SearchMethodName methodName) {
+      String[] arrayAdp = optimizer.optimize(appModel, suitableCloudOffer, null);
+      checkNotDuplicatedAdps(arrayAdp);
+      for (int adpnum = 0; adpnum < arrayAdp.length; adpnum++) {
+
+         saveFile(TestConstants.OUTPUT_FILENAME + methodName + "NOduplicates" + adpnum + ".yaml",
+               arrayAdp[adpnum]);
+      }
+
+   }
+
+   private void checkNotDuplicatedAdps(String[] arrayAdp) {
+      // load apds in maps
+      Map<String, Object>[] appMap = (Map<String, Object>[]) new Map[arrayAdp.length];
+      Map<String, Object>[] nodesMap = (Map<String, Object>[]) new Map[arrayAdp.length];
+
+      for (int i = 0; i < arrayAdp.length; i++) {
+         appMap[i] = YAMLoptimizerParser.getMAPofAPP(arrayAdp[i]);
+         nodesMap[i] = YAMLoptimizerParser.getModuleMapFromAppMap(appMap[i]);
+      }
+
+      Map<String, Object> currentMap;
+      for (int i = 0; i < nodesMap.length; i++) {
+         currentMap = nodesMap[i];
+         nodesMap[i] = null;
+         Assert.assertFalse(
+               "Map with info " + YAMLoptimizerParser.fromMAPtoYAMLstring(currentMap)
+                     + "  was found duplicated in position " + i + " and another superior ",
+               arrayContainsMapInfo(currentMap, nodesMap));
+
+         nodesMap[i] = currentMap;
+      }
+
+   }
+
+   private boolean arrayContainsMapInfo(Map<String, Object> currentMap, Map<String, Object>[] nodesMap) {
+
+      for (int i = 0; i < nodesMap.length; i++) {
+         if (isEqual(currentMap, nodesMap[i])) {
+            return true;
+         }
+      }
+      return false;
+
+   }
+
+   private boolean isEqual(Map<String, Object> current, Map<String, Object> other) {
+      if (other == null) {
+         return false;
+      }
+
+      if (current == null) {
+         return false;
+      }
+
+      if (other == current) {
+         return true;
+      }
+
+      if (current.size() != other.size()) {
+         return false;
+      }
+      for (Map.Entry<String, Object> entry : current.entrySet()) {
+         try {
+            String modname = entry.getKey();
+            if (!(other.containsKey(modname) && equalHostAndNumberInstances((Map<String, Object>) entry.getValue(),
+                  (Map<String, Object>) other.get(modname)))) {
+               return false;
+            }
+
+         } catch (Exception E) {
+            // some comparison went wrong, but modname existed (given by the
+            // order of the AND)
+            // Solutions are not equal (one should be consistent and the other
+            // should not).
+            return false;
+         }
+      }
+
+      return true;
+   }
+
+   private boolean equalHostAndNumberInstances(Map<String, Object> currentInfoMod, Map<String, Object> otherInfoMod) {
+      int numInstancesCurrent = 0;
+      String hostNameCurrent = "";
+
+      for (Map<String, Object> requirement : ((List<Map<String, Object>>) currentInfoMod
+            .get(TOSCAkeywords.MODULE_REQUIREMENTS))) {
+         try {
+            if (requirement.containsKey(TOSCAkeywords.MODULE_REQUIREMENTS_HOST)) {
+               hostNameCurrent = (String) requirement.get(TOSCAkeywords.MODULE_REQUIREMENTS_HOST);
+               numInstancesCurrent = (int) requirement.get(TOSCAkeywords.MODULE_PROPOSED_INSTANCES);
+            }
+
+         } catch (Exception E) {// Nothing to do
+            // it was not a module with host or number of instances
+         }
+      }
+
+      int numInstancesOther = 0;
+      String hostNameOther = "";
+      for (Map<String, Object> requirement : ((List<Map<String, Object>>) otherInfoMod
+            .get(TOSCAkeywords.MODULE_REQUIREMENTS))) {
+         try {
+            if (requirement.containsKey(TOSCAkeywords.MODULE_REQUIREMENTS_HOST)) {
+               hostNameOther = (String) requirement.get(TOSCAkeywords.MODULE_REQUIREMENTS_HOST);
+               numInstancesOther = (int) requirement.get(TOSCAkeywords.MODULE_PROPOSED_INSTANCES);
+            }
+
+         } catch (Exception E) {// Nothing to do
+            // it was not a module with host or number of instances
+         }
+      }
+
+      // if hostnames are not equal, return false
+      if ((hostNameCurrent == null) || (!hostNameCurrent.equals(hostNameOther))) {
+         return false;
+      }
+
+      // host names equal. Return whether the number of instances is also equal.
+      return (numInstancesCurrent == numInstancesOther);
+
+   }
+
+   @AfterClass
+   public void testFinishced() {
+      log.info("===== ALL TESTS FOR OPTIMIZER USING DECEMBER 2015 TOSCA FINISHED ===");
+   }
+
+}

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/TestConstants.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/TestConstants.java
@@ -18,7 +18,7 @@
 
 package eu.seaclouds.platform.planner.optimizerTest;
 
-public class TestConstants {
+public abstract class TestConstants {
 
    public static final boolean EnabledTest = true;
    
@@ -35,5 +35,9 @@ public class TestConstants {
    public static final int    NUM_PLANS_TO_GENERATE = 5;
 
    public static final String CLOUD_OFFER_FILENAME_IN_JSON = "./src/test/resources/mmOutputExample20Oct.json";
+   
+   
+   public static final String APP_MODEL_FILENAME_SINGLE_MODULE    = "./src/test/resources/aam_singleModule11Feb16.yml";
+   public static final String CLOUD_OFFER_FILENAME_IN_JSON_SINGLE_OFFER = "./src/test/resources/mmOutputExample20OctSingleOffer.json";
    
 }

--- a/planner/optimizer/optimizer-core/src/test/resources/aam_nuro_case_study26Jan16.yml
+++ b/planner/optimizer/optimizer-core/src/test/resources/aam_nuro_case_study26Jan16.yml
@@ -1,0 +1,89 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+description: NURO application
+imports:
+- tosca-normative-types:1.0.0.wd06-SNAPSHOT
+topology_template:
+  node_templates:
+    php:
+      type: sc_req.php
+      properties:
+        language: PHP
+        location: ''
+        autoscale: true
+        php_version:
+          constraints:
+          - greater_or_equal: '5.1'
+          - less_or_equal: '5.5'
+        credentials_file: database.properties
+      artifacts:
+      - file: https://<user>:<password>@seaclouds-dev.nurogames.com/nuro-casestudy/versions/current/nurogames-seaclouds-casestudy-php-current.tgz
+        type: tosca.artifacts.File
+      requirements:
+      - endpoint: database
+        type: seaclouds.relations.databaseconnections.php
+    database:
+      type: sc_req.database
+      properties:
+        location: ''
+        autoscale: false
+        mysql_version:
+          constraints:
+          - greater_or_equal: '5.1'
+          - less_or_equal: '5.6'
+      artifacts:
+      - db_create: https://<user>:<password>@seaclouds-dev.nurogames.com/nuro-casestudy/versions/current/create_db_and_tables-current.sql
+        type: tosca.artifacts.File
+node_types:
+  sc_req.php:
+    derived_from: seaclouds.nodes.SoftwareComponent
+    properties:
+      php_support:
+        constraints:
+        - equal: true
+      php_version:
+        constraints:
+        - greater_or_equal: '5.1'
+        - less_or_equal: '5.5'
+  sc_req.database:
+    derived_from: seaclouds.nodes.database.mysql.MySqlNode
+    properties:
+      mysql_support:
+        constraints:
+        - equal: true
+      mysql_version:
+        constraints:
+        - greater_or_equal: '5.1'
+        - less_or_equal: '5.6'
+groups:
+  operation_php:
+    members:
+    - php
+    policies:
+    - QoSInfo:
+        execution_time: 4 ms
+        benchmark_platform: Amazon_EC2_m1_large_us_east_1
+    - dependencies:
+        operation_database: '1'
+    - AppQoSRequirements:
+        response_time:
+          less_than: 2000.0 ms
+        availability:
+          greater_than: 0.99
+        cost:
+          less_or_equal: 800.0 euros_per_month
+        workload:
+          less_or_equal: 50.0 req_per_min
+    - QoSRequirements:
+        AverageResponseTime:
+          less_than: 2000.0 ms
+  operation_database:
+    members:
+    - database
+    policies:
+    - QoSInfo:
+        execution_time: 15 ms
+        benchmark_platform: Amazon_EC2_m1_large_us_east_1
+    - dependencies: {}
+    - QoSRequirements:
+        AverageResponseTime:
+          less_than: 2000.0 ms

--- a/planner/optimizer/optimizer-core/src/test/resources/aam_singleModule11Feb16.yml
+++ b/planner/optimizer/optimizer-core/src/test/resources/aam_singleModule11Feb16.yml
@@ -1,0 +1,46 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+description: Softcare
+imports:
+- tosca-normative-types:1.0.0.wd06-SNAPSHOT
+topology_template:
+  node_templates:
+    forum-webapp-20151021:
+      type: sc_req.forum-webapp-20151021
+      properties:
+        language: JAVA
+        autoscale: false
+node_types:
+  sc_req.forum-webapp-20151021:
+    derived_from: seaclouds.nodes.webapp.tomcat.TomcatServer
+    properties:
+      java_support:
+        constraints:
+        - equal: true
+      tomcat_support:
+        constraints:
+        - equal: true
+      java_version:
+        constraints:
+        - greater_or_equal: '7'
+        - less_or_equal: '8'
+      resource_type:
+        constraints:
+        - equal: platform
+groups:
+  operation_forum-webapp-20151021:
+    members:
+    - forum-webapp-20151021
+    policies:
+    - QoSInfo:
+        execution_time: 5 ms
+        benchmark_platform: Amazon_EC2_m1_medium_us_east_1
+    - dependencies: {}
+    - AppQoSRequirements:
+        response_time:
+          less_than: 200.0 ms
+        availability:
+          greater_than: 0.99
+        cost:
+          less_or_equal: 1000.0 euros_per_month
+        workload:
+          less_or_equal: 240.0 req_per_min

--- a/planner/optimizer/optimizer-core/src/test/resources/mmOutputExample20OctSingleOffer.json
+++ b/planner/optimizer/optimizer-core/src/test/resources/mmOutputExample20OctSingleOffer.json
@@ -1,0 +1,5 @@
+[ {
+  "forum-webapp-20151021" : [ {
+    "6184608484337307426" : "Cloud_Foundry: \n  properties: \n    auto_scaling: false\n    availability: 0.99871\n    cost: 0.04\n    go_support: true\n    go_version: 1.4\n    horizontal_scaling: true\n    java_support: true\n    location: CloudFoundry\n    node_support: true\n    performance: 192\n    php_support: true\n    private_hosting: true\n    public_hosting: false\n    python_support: true\n    resource_type: platform\n    ruby_support: true\n    scala_support: true\n    tomcat_support: true\n    tomcat_version: 7\n    vertical_scaling: true\n  type: seaclouds.nodes.Platform.Cloud_Foundry\n"
+  } ]
+ } ]


### PR DESCRIPTION
This PR avoids returning replicated ADPs in case that there exist just a very few cloud combinations. 

It is intended to solve issue #240 

It includes tests for the AAM that raised the issue; an AAM with only one module and just one cloud offer as possibility. 