### PR TITLE
FEATURE: AAM contains db_name, db_user, db_password properties

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
@@ -88,6 +88,14 @@
                                 <input type="text" class="form-control" id="database-artifact"
                                        placeholder="http://www.server.com/path">
                             </div>
+                            <div class="form-group">
+                                <label for="database-name">Database</label>
+                                <input type="text" class="form-control" id="database-name">
+                                <label for="database-user">User</label>
+                                <input type="text" class="form-control" id="database-user">
+                                <label for="database-pwd">Password</label>
+                                <input type="text" class="form-control" id="database-pwd">
+                            </div>
                         </fieldset>
                         <fieldset id="set-nonfunctional">
                             <legend>Non-functional Requirements <a href="#"><i class="fa fa-chevron-down"> </i></a>

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -496,6 +496,10 @@ var Editor = (function() {
         );
         $("#database-min-version").val(node.properties.min_version);
         $("#database-max-version").val(node.properties.max_version);
+
+        $("#database-name").val(node.properties.db_name);
+        $("#database-user").val(node.properties.db_user);
+        $("#database-pwd").val(node.properties.db_password);
     };
 
     databasetechset.store = function(node) {
@@ -503,6 +507,9 @@ var Editor = (function() {
         node.properties.artifact = $("#database-artifact").val();
         node.properties.min_version = $("#database-min-version").val();
         node.properties.max_version = $("#database-max-version").val();
+        node.properties.db_name = $("#database-name").val();
+        node.properties.db_user = $("#database-user").val();
+        node.properties.db_password = $("#database-pwd").val();
     };
 
     nonfunctionalset.nonfunctionalset = function(fieldsetid) {

--- a/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/TranslatorTest.java
+++ b/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/TranslatorTest.java
@@ -202,6 +202,10 @@ public class TranslatorTest {
 
         checkProperty(n1, "autoscale", graph.getNode("www").getOtherProperties().get("autoscale"));
         checkProperty(n3, "autoscale", graph.getNode(N3).getOtherProperties().get("autoscale"));
+        
+        checkProperty(n3, "db_name", graph.getNode(N3).getOtherProperties().get("db_name"));
+        checkProperty(n3, "db_user", graph.getNode(N3).getOtherProperties().get("db_user"));
+        checkProperty(n3, "db_password", graph.getNode(N3).getOtherProperties().get("db_password"));
     }
     
     @Test

--- a/planner/aamwriter/src/test/resources/translator.json
+++ b/planner/aamwriter/src/test/resources/translator.json
@@ -66,6 +66,9 @@
                 "min_version": "5.0",
                 "max_version": "5.6",
                 "artifact": "mysql_script.sql",
+                "db_name": "<db_name>",
+                "db_user": "<db_user>",
+                "db_password": "<db_password>",
             }
         },
         {


### PR DESCRIPTION
This PR adds db_name, db_user and db_password properties in the AAM for the database nodes. It also adds the fields needed in the UI to collect this data.

The following json topology
```
{
	"name": "example",
	"nodes": [{
		"name": "db1",
		"label": "db1",
		"type": "Database",
		"properties": {
			"category": "database.mysql.MySqlNode",
			"autoscale": true,
			"artifact": "",
			"min_version": "5",
			"max_version": "5",
			"db_name": "$DB_NAME",
			"db_user": "$DB_USER",
			"db_password": "$DB_PWD",
			"qos": [],
			"benchmark_rt": "",
			"benchmark_platform": ""
		},
	}],
	"links": [],
	"application_requirements": {
		"response_time": "2000",
		"availability": 0.98,
		"cost": "200",
		"workload": "50"
	}
}
```

generates the following AAM:
```
tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
description: example
imports:
- tosca-normative-types:1.0.0.wd06-SNAPSHOT
topology_template:
  node_templates:
    db1:
      type: sc_req.db1
      properties:
        db_name: $DB_NAME
        autoscale: true
        db_password: $DB_PWD
        db_user: $DB_USER
        mysql_version:
          constraints:
          - greater_or_equal: '5'
          - less_or_equal: '5'
node_types:
  sc_req.db1:
    derived_from: seaclouds.nodes.database.mysql.MySqlNode
    properties:
      mysql_support:
        constraints:
        - equal: true
      mysql_version:
        constraints:
        - greater_or_equal: '5'
        - less_or_equal: '5'
groups:
  operation_db1:
    members:
    - db1
    policies:
    - dependencies: {}
    - AppQoSRequirements:
        response_time:
          less_than: 2000.0 ms
        availability:
          greater_than: 0.98
        cost:
          less_or_equal: 200.0 euros_per_month
        workload:
          less_or_equal: 50.0 req_per_min```
