### PR TITLE
Avoids log4j-over-slf4j recursion

### DIFF
--- a/sla/sla-core/sla-personalization/pom.xml
+++ b/sla/sla-core/sla-personalization/pom.xml
@@ -63,6 +63,16 @@
 		<dependency>
 			<groupId>it.polimi.tower4clouds</groupId>
 			<artifactId>rules</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jcl-over-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
sla-personalization depends on tower4clouds:rules, which 
depends on log4j-over-slf4j. This leads to an exception at runtime
described in http://www.slf4j.org/codes.html#log4jDelegationLoop

This commits adds the exclusions needed to work around the problem. Although it is not affecting the SLA in SeaClouds (I don't know why), it has affected in other contexts, and therefore may affect SeaClouds SLA in the future.

The exclusions may be added to the parent pom instead of sla-personalization, but I would need agreement from the other modules. 

@andreaturli , @kiuby88 , @adriannieto , @MicheleGuerriero : WDYT?