### PR TITLE
FIX(replacing offerings type during DAM generation)

### DIFF
--- a/planner/service/plannerconf.yml
+++ b/planner/service/plannerconf.yml
@@ -6,10 +6,10 @@ server:
     type: http
     port: 1234
 discovererURL: http://52.49.115.206:1236/
-monitorGeneratorURL: 52.48.12.68
+monitorGeneratorURL: 52.48.187.2
 monitorGeneratorPort: 8170
-slaGeneratorURL: http://95.211.172.242:9003
-deployableProviders: ["openstack-nova","openstack-keystone","openstack-nova-ec2", "byon", "sts", "elasticstack", "cloudstack", "rackspace-cloudidentity","aws-ec2","gogrid","elastichosts-lon-p","elastichosts-sat-p","elastichosts-lon-b","openhosting-east1","serverlove-z1-man","skalicloud-sdg-my","go2cloud-jhb1","softlayer","hpcloud-compute","rackspace-cloudservers-us","rackspace-cloudservers-uk","azurecompute","google-compute-engine","CloudFoundry"]
+slaGeneratorURL: http://52.36.119.104:9003
+deployableProviders: ["aws-ec2"]
 filterOfferings: true
 influxdbPort: 8086
-influxdbURL: 52.48.12.68
+influxdbURL: 52.48.187.2


### PR DESCRIPTION
This PR adds the code to:

- replace offerings type (seaclouds.nodes.Compute.xxx and seaclouds.nodes.Platform.xxx) with tosca.nodes.Compute or tosca.nodes.Platform
- remove the requirement {endpoint:"", type:""} that is not supported yet by the deployer