### PR TITLE
Avoiding NodeTypes in Sample DAMs

### DIFF
--- a/deployer/src/test/resources/dams/no-artifacs/Noart.DynamicWeb-compute-mysql-compute.yaml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.DynamicWeb-compute-mysql-compute.yaml
@@ -2,46 +2,12 @@ tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 
 imports:
   - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
 
 template_name: web-chat.cluster-compute.mysql-compute
 template_version: 1.0.0-SNAPSHOT
 
 description: Chat Application using a ControlledDynamicWebAppCluster
-
-node_types:
-  org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple ControlledDynamicWebAppCluster
-    properties:
-      http.port:
-        type: list
-        required: false
-        entry_schema:
-          type: string
-      java.sysprops:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      wars.root:
-        type: string
-        required: false
-    requirements:
-      - host: tosca.nodes.Compute
-        type: tosca.relationships.HostedOn
-
-  org.apache.brooklyn.entity.database.mysql.MySqlNode:
-    derived_from: tosca.nodes.Root
-    description: |
-      A MySQL server
-    properties:
-      creationScriptUrl:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
 
 topology_template:
   description: Web Server Sample with Script
@@ -52,7 +18,7 @@ topology_template:
         http.port: "8080+"
         wars.root: "http://search.maven.org/remotecontent?filepath=io/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.6.0/brooklyn-example-hello-world-sql-webapp-0.6.0.war"
         java.sysprops:
-          brooklyn.example.db.url: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
+          brooklyn.example.db.url: $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s", component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
       requirements:
       - host: Amazon_EC2_i2_xlarge_us_west_2
 

--- a/deployer/src/test/resources/dams/no-artifacs/Noart.DynamicWeb-policies-compute-mysql-compute.yaml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.DynamicWeb-policies-compute-mysql-compute.yaml
@@ -2,43 +2,13 @@ tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 
 imports:
   - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
+
 
 template_name: web-chat.cluster-policy-compute.mysql-compute
 template_version: 1.0.0-SNAPSHOT
 
 description: Chat Application using JBoss
-
-node_types:
-  org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple ControlledDynamicWebAppCluster
-    properties:
-      http.port:
-        type: list
-        required: false
-        entry_schema:
-          type: string
-      java.sysprops:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      wars.root:
-        type: string
-        required: false
-
-  org.apache.brooklyn.entity.database.mysql.MySqlNode:
-    derived_from: tosca.nodes.Root
-    description: |
-      A MySQL server
-    properties:
-      creationScriptUrl:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
 
 topology_template:
   description: Web Server Sample with Script

--- a/deployer/src/test/resources/dams/no-artifacs/Noart.jboss-DC-compute-mysql-compute.yaml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.jboss-DC-compute-mysql-compute.yaml
@@ -2,64 +2,12 @@ tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 
 imports:
   - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
 
 template_name: web-chat.jboss.dc-compu.mysql.compute
 template_version: 1.0.0-SNAPSHOT
 
 description: Chat Application using JBoss
-
-node_types:
-  org.apache.brooklyn.entity.webapp.jboss.JBoss7Server:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple Tomcat server
-    properties:
-      http.port:
-        type: list
-        required: false
-        entry_schema:
-          type: string
-      java.sysprops:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      wars.root:
-        type: string
-        required: false
-    requirements:
-      - host: tosca.nodes.Compute
-        type: tosca.relationships.HostedOn
-
-  org.apache.brooklyn.entity.database.mysql.MySqlNode:
-    derived_from: tosca.nodes.Root
-    description: |
-      A MySQL server
-    properties:
-      creationScriptUrl:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
-
-
-  seaclouds.nodes.Datacollector:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple DC
-    properties:
-      install_latch:
-        type: string
-        required: false
-      shell.env:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
 
 topology_template:
   description: Web Server Sample with Script
@@ -77,7 +25,7 @@ topology_template:
     dc:
       type: seaclouds.nodes.Datacollector
       properties:
-        install_latch: $brooklyn:component("tomcat_server").attributeWhenReady("service.isUp")
+        installLatch: $brooklyn:component("tomcat_server").attributeWhenReady("service.isUp")
       requirements:
       - host: Amazon_EC2_i2_xlarge_us_west_2
 

--- a/deployer/src/test/resources/dams/no-artifacs/Noart.php-DC-compute-mysql-compute.yml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.php-DC-compute-mysql-compute.yml
@@ -3,7 +3,9 @@ description: Nuro application. No artifacts. All components are hosted
 template_name: nuro.php-dc-compute-mysql-compute.na
 template_version: 1.0.0-SNAPSHOT
 imports:
-- tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
+
 topology_template:
   node_templates:
     php:
@@ -106,59 +108,3 @@ topology_template:
       - brooklyn.location: aws-ec2:us-west-2
       members:
       - Amazon_EC2_m3_xlarge_eu_central_1
-
-node_types:
-  org.apache.brooklyn.entity.database.mysql.MySqlNode:
-    derived_from: tosca.nodes.Root
-    description: |
-      A MySQL server
-    properties:
-      creationScriptUrl:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
-
-  org.apache.brooklyn.entity.php.httpd.PhpHttpdServer:
-    derived_from: tosca.nodes.Root
-    description: |
-      A simple Tomcat server
-    properties:
-      php.app.name:
-        type: string
-        required: false
-      config.file:
-        type: string
-        required: false
-      config.params:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      git.url:
-        type: string
-        required: false
-      tarball.url:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
-
-  seaclouds.nodes.Datacollector:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple DC
-    properties:
-      installLatch:
-        type: string
-        required: false
-      shell.env:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn

--- a/deployer/src/test/resources/dams/no-artifacs/Noart.php-DC-compute.yml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.php-DC-compute.yml
@@ -3,7 +3,9 @@ description: Nuro application and Datacollector. No artifacts. All components ar
 template_name: nuro.php-dc-compute.na
 template_version: 1.0.0-SNAPSHOT
 imports:
-- tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
+
 topology_template:
   node_templates:
     php:
@@ -71,48 +73,3 @@ topology_template:
       - brooklyn.location: aws-ec2:us-west-2
       members:
       - php_compute
-
-node_types:
-
-  org.apache.brooklyn.entity.php.httpd.PhpHttpdServer:
-    derived_from: tosca.nodes.Root
-    description: |
-      A simple Tomcat server
-    properties:
-      php.app.name:
-        type: string
-        required: false
-      config.file:
-        type: string
-        required: false
-      config.params:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      git.url:
-        type: string
-        required: false
-      tarball.url:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
-
-  seaclouds.nodes.Datacollector:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple DC
-    properties:
-      installLatch:
-        type: string
-        required: false
-      shell.env:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn

--- a/deployer/src/test/resources/dams/no-artifacs/Noart.php-compute-mysql-compute.yml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.php-compute-mysql-compute.yml
@@ -2,8 +2,11 @@ tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 description: Nuro application. No artifacts. All components are hosted
 template_name: nuro.php-compute-mysql-compute.na
 template_version: 1.0.0-SNAPSHOT
+
 imports:
-- tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
+
 topology_template:
   node_templates:
     php:
@@ -85,42 +88,3 @@ topology_template:
       - brooklyn.location: aws-ec2:us-west-2
       members:
       - Amazon_EC2_m3_xlarge_eu_central_1
-
-node_types:
-  org.apache.brooklyn.entity.database.mysql.MySqlNode:
-    derived_from: tosca.nodes.Root
-    description: |
-      A MySQL server
-    properties:
-      creationScriptUrl:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
-
-  org.apache.brooklyn.entity.php.httpd.PhpHttpdServer:
-    derived_from: tosca.nodes.Root
-    description: |
-      A simple Tomcat server
-    properties:
-      php.app.name:
-        type: string
-        required: false
-      config.file:
-        type: string
-        required: false
-      config.params:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      git.url:
-        type: string
-        required: false
-      tarball.url:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn

--- a/deployer/src/test/resources/dams/no-artifacs/Noart.php-mysql-compute.yml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.php-mysql-compute.yml
@@ -3,7 +3,9 @@ description: Nuro application. Mysql is hosted. No artifacs
 template_name: nuro.php.mysql-compute.na
 template_version: 1.0.0-SNAPSHOT
 imports:
-- tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
+
 topology_template:
   node_templates:
     php:
@@ -64,42 +66,3 @@ topology_template:
       - brooklyn.location: aws-ec2:us-west-2
       members:
       - Amazon_EC2_m3_xlarge_eu_central_1
-
-node_types:
-  org.apache.brooklyn.entity.database.mysql.MySqlNode:
-    derived_from: tosca.nodes.Root
-    description: |
-      A MySQL server
-    properties:
-      creationScriptUrl:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
-
-  org.apache.brooklyn.entity.php.httpd.PhpHttpdServer:
-    derived_from: tosca.nodes.Root
-    description: |
-      A simple Tomcat server
-    properties:
-      php.app.name:
-        type: string
-        required: false
-      config.file:
-        type: string
-        required: false
-      config.params:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      git.url:
-        type: string
-        required: false
-      tarball.url:
-        type: string
-        required: false
-    #requirements:
-    #- host: seaclouds.nodes.Compute
-    #  type: tosca.relationships.HostedOn

--- a/deployer/src/test/resources/dams/no-artifacs/Noart.tomcat-DC-compute-mysql-compute.yaml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.tomcat-DC-compute-mysql-compute.yaml
@@ -2,64 +2,12 @@ tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 
 imports:
   - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
 
 template_name: web-chat.tomca-dc-compute.mysql-compute.na
 template_version: 1.0.0-SNAPSHOT
 
 description: Web chat using tomcat and DC. All component are hosted. No artifacts
-
-node_types:
-  org.apache.brooklyn.entity.webapp.tomcat.TomcatServer:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple Tomcat server
-    properties:
-      http.port:
-        type: list
-        required: false
-        entry_schema:
-          type: string
-      java.sysprops:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      wars.root:
-        type: string
-        required: false
-    requirements:
-      - host: tosca.nodes.Compute
-        type: tosca.relationships.HostedOn
-
-  org.apache.brooklyn.entity.database.mysql.MySqlNode:
-    derived_from: tosca.nodes.Root
-    description: |
-      A MySQL server
-    properties:
-      creationScriptUrl:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
-
-
-  seaclouds.nodes.Datacollector:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple DC
-    properties:
-      install_latch:
-        type: string
-        required: false
-      shell.env:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
 
 topology_template:
   description: Web Server Sample with Script
@@ -77,7 +25,7 @@ topology_template:
     dc:
       type: seaclouds.nodes.Datacollector
       properties:
-        install_latch: $brooklyn:component("tomcat_server").attributeWhenReady("service.isUp")
+        installLatch: $brooklyn:component("tomcat_server").attributeWhenReady("service.isUp")
       requirements:
       - host: Amazon_EC2_i2_xlarge_us_west_2
 

--- a/deployer/src/test/resources/dams/no-artifacs/Noart.tomcat-compute-mysql-compute.yaml
+++ b/deployer/src/test/resources/dams/no-artifacs/Noart.tomcat-compute-mysql-compute.yaml
@@ -2,47 +2,13 @@ tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
 
 imports:
   - tosca-normative-types:1.0.0.wd06-SNAPSHOT
+  - seaclouds-types:0.8.0-SNAPSHOT
+
 
 template_name: web-chat.tomcat-compute.mysql-compute.na
 template_version: 1.0.0-SNAPSHOT
 
 description: Web chat using tomcat. No artifacts. All compontent are hosted
-
-node_types:
-  org.apache.brooklyn.entity.webapp.tomcat.TomcatServer:
-    derived_from: tosca.nodes.Root
-    description: >
-      A simple Tomcat server
-    properties:
-      http.port:
-        type: list
-        required: false
-        entry_schema:
-          type: string
-      java.sysprops:
-        type: map
-        required: false
-        entry_schema:
-          type: string
-      wars.root:
-        type: string
-        required: false
-    requirements:
-      - host: tosca.nodes.Compute
-        type: tosca.relationships.HostedOn
-
-  org.apache.brooklyn.entity.database.mysql.MySqlNode:
-    derived_from: tosca.nodes.Root
-    description: |
-      A MySQL server
-    properties:
-      creationScriptUrl:
-        type: string
-        required: false
-    requirements:
-    - host: tosca.nodes.Compute
-      type: tosca.relationships.HostedOn
-
 
 topology_template:
   description: Web Server Sample with Script


### PR DESCRIPTION
DAMs do not require NodeTypes definitions. [SeaClouds NodeTypes](https://github.com/SeaCloudsEU/seaclouds-types) are pre-loaded in the SeaClouds Deployer.