### PR TITLE
Adds the env var where an endpoint url is stored.

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-view.html
@@ -240,9 +240,9 @@
                                 <select class="form-control" id="operation-type"> </select>
                             </div>
                             <div class="form-group">
-                                <label for="operation-credentials-file">File where to store credentials</label>
-                                <input type="text" class="form-control" id="operation-credentials-file"
-                                       placeholder="database.properties">
+                                <label for="operation-env-var">Env var to store endpoint URL</label>
+                                <input type="text" class="form-control" id="operation-env-var"
+                                       placeholder="connurl">
                             </div>
                             <div class="form-group">
                                 <label for="operation-calls">Average number of calls</label>

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.js
@@ -674,13 +674,13 @@ var Editor = (function() {
 
     operationsset.load = function(link) {
         $("#operation-calls").val(link.properties.calls);
-        $("#operation-credentials-file").val(link.properties.credentials_file);
+        $("#operation-env-var").val(link.properties.env_var);
         $("#operation-type").val(link.properties.operation_type);
     };
 
     operationsset.store = function(link) {
         link.properties.calls = $("#operation-calls").val();
-        link.properties.credentials_file = $("#operation-credentials-file").val();
+        link.properties.env_var = $("#operation-env-var").val();
         link.properties.operation_type = $("#operation-type").val();
     };
 

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
@@ -216,10 +216,7 @@ public class Translator {
         NodeTemplate source = topologyTemplate.getNodeTemplate(dSource.getName());
         NodeTemplate target = topologyTemplate.getNodeTemplate(dTarget.getName());
         
-        source.addConnectionRequirement(target, l.getOperationType());
-        if (!l.getCredentialsFile().isEmpty()) {
-            source.addProperty(DLink.Attributes.CREDENTIALS_FILE, l.getCredentialsFile());
-        }
+        source.addConnectionRequirement(target, l.getOperationType(), l.getEnvVar());
     }
 
     private void buildGroups(DGraph dgraph, Aam aam) {

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/NodeTemplate.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modelaam/NodeTemplate.java
@@ -35,7 +35,7 @@ public class NodeTemplate extends LinkedHashMap {
     private String name;
     private Map _properties = new LinkedHashMap();
     private List<Map<String, String>> _artifacts = new ArrayList();
-    private List<Map<String, String>> _requirements = new ArrayList();
+    private List<Map<String, Object>> _requirements = new ArrayList();
     
     public NodeTemplate(String name) {
         this.name = name;
@@ -79,13 +79,13 @@ public class NodeTemplate extends LinkedHashMap {
     
     public void setHostRequirement(NodeTemplate node) {
         
-        for (Map<String, String> item : _requirements) {
+        for (Map<String, Object> item : _requirements) {
             if (item.containsKey("host")) {
                 item.put("host", node.getName());
                 return;
             }
         }
-        Map<String, String> requirement = new LinkedHashMap();
+        Map<String, Object> requirement = new LinkedHashMap();
         requirement.put("host", node.getName());
         
         requirements().add(requirement);
@@ -95,12 +95,17 @@ public class NodeTemplate extends LinkedHashMap {
      * Add an endpoint requirement to a NodeTemplate
      * @return name given to the requirement
      */
-    public String addConnectionRequirement(NodeTemplate target, String type) {
-        Map<String, String> requirement = new LinkedHashMap();
+    public String addConnectionRequirement(NodeTemplate target, String type, String varName) {
+        Map<String, Object> requirement = new LinkedHashMap();
         
         String requirementName = "endpoint";
         requirement.put(requirementName, target.getName());
         requirement.put("type", type);
+        if (!varName.isEmpty()) {
+            Map<String, String> properties = new LinkedHashMap();
+            properties.put("prop.name", varName);
+            requirement.put("properties", properties);
+        }
         requirements().add(requirement);
         
         return requirementName;
@@ -130,7 +135,7 @@ public class NodeTemplate extends LinkedHashMap {
         return _artifacts;
     }
     
-    private List<Map<String, String>> requirements() {
+    private List<Map<String, Object>> requirements() {
         if (!this.containsKey(Attributes.REQUIREMENTS)) {
             this.put(Attributes.REQUIREMENTS, _requirements);
         }

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DLink.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DLink.java
@@ -36,6 +36,7 @@ public class DLink {
         public static final String CALLS = "calls";
         public static final String TYPE = "operation_type";
         public static final String CREDENTIALS_FILE = "credentials_file";
+        public static final String ENV_VAR = "env_var";
     }
 
     private DGraph graph;
@@ -45,6 +46,7 @@ public class DLink {
     private String calls;
     private String operationType;
     private String credentialsFile;
+    private String envVar;
 
     public DLink(JSONObject jnode, DGraph graph) {
         this.graph = graph;
@@ -62,6 +64,7 @@ public class DLink {
         this.calls = properties.containsKey(Attributes.CALLS)? properties.get(Attributes.CALLS) : "";
         this.operationType = properties.containsKey(Attributes.TYPE)? properties.get(Attributes.TYPE) : "";
         this.credentialsFile = properties.containsKey(Attributes.CREDENTIALS_FILE)? properties.get(Attributes.CREDENTIALS_FILE) : "";
+        this.envVar = properties.containsKey(Attributes.ENV_VAR)? properties.get(Attributes.ENV_VAR) : "";
     }
 
     @Override
@@ -88,5 +91,9 @@ public class DLink {
     
     public String getOperationType() {
         return operationType;
+    }
+    
+    public String getEnvVar() {
+        return envVar;
     }
 }

--- a/planner/aamwriter/src/test/resources/translator.json
+++ b/planner/aamwriter/src/test/resources/translator.json
@@ -115,7 +115,8 @@
             "target": "webservices",
             "properties": {
                 "calls": "2",
-                "operation_type": "seaclouds.relation.connection.endpoint.host"
+                "operation_type": "seaclouds.relation.connection.endpoint.host",
+                "env_var": "connurl"
             }
         },
         {


### PR DESCRIPTION
The link form in the designer asks for the env var.
The env var is introduced in the AAM at aamwriter time.

This also removes a previous feature where credentials were stored in a
file.

For example, the following topology:

```
    [...]
    "links": [
        {
            "source": "www",
            "target": "webservices",
            "properties": {
                "calls": "2",
                "operation_type": "seaclouds.relation.connection.endpoint.host",
                "env_var": "connurl"
            }
        },
    [...]
```

generates the following requirement in the node template:

```
    www:
      type: sc_req.www
      properties:
        language: JAVA
        location: DYNAMIC
        location_option: FOLLOW_SUN
        autoscale: true
      artifacts:
      - wars.root: http://www.example.com/downloads/www.war
        type: tosca.artifacts.File
      requirements:
      - endpoint: webservices
        type: seaclouds.relation.connection.endpoint.host
        properties:
          prop.name: connurl
```

@kiuby88 : Could you review?