### PR TITLE
FIX: create autoscaler policy with agnostic information

### DIFF
--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/Solution.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/Solution.java
@@ -143,6 +143,10 @@ public class Solution implements Iterable<String>, Comparable<Solution> {
       }
 
       sol.solutionFitness = this.solutionFitness;
+      sol.solutionQuality=null;
+      if(this.solutionQuality!=null){
+         sol.solutionQuality = new QualityInformation(this.solutionQuality);
+      }
       return sol;
    }
 

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/Anneal.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/Anneal.java
@@ -45,7 +45,7 @@ public class Anneal extends AbstractHeuristic implements SearchMethod {
    @Override
    public Solution[] computeOptimizationProblemForAllDifferentSolutions(SuitableOptions cloudOffers, QualityInformation requirements,
          Topology topology, int numPlansToGenerate) {
-      return super.filterUniqueSolutions(computeOptimizationProblem(cloudOffers,requirements,topology,numPlansToGenerate));
+      return filterUniqueSolutions(computeOptimizationProblem(cloudOffers,requirements,topology,numPlansToGenerate));
    }
    
    @Override

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/HillClimb.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/HillClimb.java
@@ -47,7 +47,7 @@ public class HillClimb extends AbstractHeuristic implements SearchMethod {
    @Override
    public Solution[] computeOptimizationProblemForAllDifferentSolutions(SuitableOptions cloudOffers, QualityInformation requirements,
          Topology topology, int numPlansToGenerate) {
-      return super.filterUniqueSolutions(computeOptimizationProblem(cloudOffers,requirements,topology,numPlansToGenerate));
+      return filterUniqueSolutions(computeOptimizationProblem(cloudOffers,requirements,topology,numPlansToGenerate));
    }
 
    /*

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
@@ -138,6 +138,7 @@ public class QualityAnalyzer {
          log.debug("calculated response time of the solution" + bestSol.toString() + " is: " + respTime);
       }
       // after computing, save the performance info in properties.performance
+      properties.setWorkload(workload);
       properties.setResponseTimeSecs(respTime);
 
       return properties;

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityInformation.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityInformation.java
@@ -27,6 +27,16 @@ public class QualityInformation {
    private double              cost           = 0;      // in moneyUnits/hour
    private double              workload       = 0;      // in seconds
 
+   
+   public QualityInformation(QualityInformation qi) {
+     this.respTime = qi.respTime;
+     this.availability=qi.availability;
+     this.cost=qi.cost;
+     this.workload=qi.workload;
+   }
+
+   public QualityInformation() {}
+   
    public double getResponseTime() {
       return respTime;
    }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/ScalingPolicy.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/ScalingPolicy.java
@@ -32,6 +32,7 @@ public class ScalingPolicy {
       autoscaleValues.put(TOSCAkeywords.AUTOSCALE_METRIC_UPPERBOUND, wklUpperBound);
       autoscaleValues.put(TOSCAkeywords.AUTOSCALE_POOL_MINIMUM_SIZE, minPoolSize);
       autoscaleValues.put(TOSCAkeywords.AUTOSCALE_POOL_MAXIMUM_SIZE, maxPoolSize);
+      autoscaleValues.put(TOSCAkeywords.AUTOSCALE_STABILIZATION_DELAY, TOSCAkeywords.AUTOSCALE_STABILIZATION_DELAY_VALUE_MILLISECONDS);
       
       Map<String, Object> policy = new HashMap<String,Object>();
       policy.put(TOSCAkeywords.AUTOSCALING_TAG, autoscaleValues);

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
@@ -91,16 +91,18 @@ public class TOSCAkeywords {
    // These ones are for the autoscaling policies
    public static final String AUTOSCALING_TAG                                  = "autoscaling";
    public static final String AUTOSCALE_TYPE                                   = "type";
-   public static final String AGNOSTIC_AUTOSCALER_POLICY                       = "seaclouds.policies.autoscalling.AutoscalerPolicy";
+   public static final String AGNOSTIC_AUTOSCALER_POLICY                       = "seaclouds.policies.autoscaling.AutoScalerPolicy";
    public static final String BROOKLYN_AUTOSCALER_POLICY                       = "org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy";
    public static final String NODE_TYPE_AUTOSCALABLE                           = "seaclouds.nodes.ControlledDynamicWebAppCluster";
    public static final String AUTOSCALE_METRIC                                 = "metric";
    public static final String BROOKLYN_AUTOSCALER_METRIC_ARRIVALRATE_PER_SECOND = "$brooklyn:sensor(\"org.apache.brooklyn.entity.webapp.DynamicWebAppCluster\", \"webapp.reqs.perSec.windowed.perNode\")";
-   public static final String AGNOSTIC_AUTOSCALER_METRIC_ARRIVALRATE_PER_SECOND = "$brooklyn:sensor(\"seaclouds.nodes.ControlledDynamicWebAppCluster\", \"webapp.reqs.perSec.windowed.perNode\")";
+   public static final String AGNOSTIC_AUTOSCALER_METRIC_ARRIVALRATE_PER_SECOND = "seaclouds.metrics.requestPerNode";
    public static final String AUTOSCALE_METRIC_LOWERBOUND                      = "metricLowerBound";
    public static final String AUTOSCALE_METRIC_UPPERBOUND                      = "metricUpperBound";
    public static final String AUTOSCALE_POOL_MINIMUM_SIZE                      = "minPoolSize";
    public static final String AUTOSCALE_POOL_MAXIMUM_SIZE                      = "maxPoolSize";
+   public static final String AUTOSCALE_STABILIZATION_DELAY                    = "autoscaler.resizeDownStabilizationDelay";
+   public static final int    AUTOSCALE_STABILIZATION_DELAY_VALUE_MILLISECONDS = 120000; //two minutes (exp. booting time).
    
    //This is to define the Compute node type
    public static final String COMPUTE_TYPE = "seaclouds.nodes.Compute";

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015AutoscalingPoliciesTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015AutoscalingPoliciesTest.java
@@ -137,6 +137,7 @@ public class OptimizerTOSCADecember2015AutoscalingPoliciesTest extends AbstractT
                Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_METRIC_LOWERBOUND));
                Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_METRIC_UPPERBOUND));
                Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_POOL_MINIMUM_SIZE));
+               Assert.assertTrue(autoscalingPolicy.containsKey(TOSCAkeywords.AUTOSCALE_STABILIZATION_DELAY));
 
                String typeOfNode = YAMLmodulesOptimizerParser.getModuleTypeFromModulesMap(entry.getKey(), nodesMap);
                Assert.assertNotNull("Type of node " + entry.getKey() + " was NULL", typeOfNode);

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/nfp/QualityAnalyzerTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/nfp/QualityAnalyzerTest.java
@@ -40,6 +40,7 @@ public class QualityAnalyzerTest {
 
    private static QualityAnalyzer analyzer;
 
+   private static final double WORKLOAD = 10.0;
 
    static Logger log;
 
@@ -67,11 +68,11 @@ public class QualityAnalyzerTest {
       Solution bestSol = createSolution();
       Topology topology = createTopology();
 
-      double workload = 10;
+
 
       SuitableOptions cloudCharacteristics = createSuitableOptions();
 
-      QualityInformation qInfo = analyzer.computePerformance(bestSol, topology, workload, cloudCharacteristics);
+      QualityInformation qInfo = analyzer.computePerformance(bestSol, topology, WORKLOAD, cloudCharacteristics);
 
       Assert.assertTrue("Compute performance returned null", qInfo != null);
 
@@ -127,13 +128,19 @@ public class QualityAnalyzerTest {
       log.info("==== TEST for RECONFIGURATION THRESHOLDS starts ====");
       Solution bestSol = createSolution();
       Topology topology = createTopology();
+      
       SuitableOptions cloudCharacteristics = createSuitableOptions();
 
       QualityInformation requirements = new QualityInformation();
       requirements.setResponseTimeSecs(1000.0);
-      requirements.setWorkload(10.0);
+      requirements.setWorkload(WORKLOAD);
       requirements.setCostHour(40.0);
+      
+      //the computation of thresholds needs the workload value
+      analyzer.getAllComputedQualities().setWorkload(WORKLOAD);
+      bestSol.setSolutionQuality(analyzer.getAllComputedQualities());
 
+      
       HashMap<String, ArrayList<Double>> thresholds = analyzer.computeThresholds(bestSol, topology, requirements,
             cloudCharacteristics);
       Assert.assertTrue("Compute thresholds returns null", thresholds != null);


### PR DESCRIPTION
Changed the optimizer code to create policies with the structure as in the following example: 
```
 policies:
      - autoscaling:
          type: seaclouds.policies.autoscaling.AutoScalerPolicy
          metric: seaclouds.metrics.requestPerNode
          autoscaler.resizeDownStabilizationDelay: 120000
          metricLowerBound: N1
          metricUpperBound: N2
          minPoolSize: N3
          maxPoolSize: N4
```