### PR TITLE
Scaling policies optimizer

### DIFF
--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/CloudOffer.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/CloudOffer.java
@@ -20,7 +20,6 @@ package eu.seaclouds.platform.planner.optimizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
 
 
 public class CloudOffer {

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/OptimizerInitialDeployment.java
@@ -149,8 +149,19 @@ public class OptimizerInitialDeployment {
       log.debug("Getting application Requirements");
 
       QualityInformation requirements = loadQualityRequirements(appMap);
-
       log.debug("following requirements found: " + requirements.toString());
+
+      // Check whether topology the topology includes information for the
+      // computation of the
+      // response time. If it does not include such info, remove the response
+      // time requirement
+      // from the requirements because it cannot be computed
+      if (!topology.modulesHavePerformanceInformation()) {
+         requirements.disableResponseTimeRequirement();
+         log.info("Performance requirement disabled because it was not performance information in the input");
+         YAMLoptimizerParser.setModelDescriptionOfAppMap(appMap,
+               YAMLoptimizerParser.getModelDescriptionFromAppMap(appMap) + " (WITHOUT RESPONSE TIME REQUIREMENT)");
+      }
 
       // Create the skeleton of the numPlansToGenerate solutions to fill
       // This is only to avoid using the appMap or call to the TOSCA parser
@@ -161,7 +172,7 @@ public class OptimizerInitialDeployment {
             requirements, topology, numPlansToGenerate);
 
       log.debug("After invocation of the optimization problem");
-      
+
       if (solutions == null) {
          log.error("Map returned by Search engine is null");
       }
@@ -230,7 +241,8 @@ public class OptimizerInitialDeployment {
          // use
          // addReconfigurationThresholds mehtod from YAMLoptimizerParser class.
          if (thresholds != null) {
-            addWorkloadAndPoolSizeBoundsForAllScalableModules(bestSols[i], thresholds, baseAppMap, topology, hyst, requirements);
+            addWorkloadAndPoolSizeBoundsForAllScalableModules(bestSols[i], thresholds, baseAppMap, topology, hyst,
+                  requirements);
             log.debug("After adding the reconfiguration thesholds to the map. Thresholds found are: ");
          } else {
             log.debug(
@@ -243,47 +255,46 @@ public class OptimizerInitialDeployment {
    }
 
    private void addWorkloadAndPoolSizeBoundsForAllScalableModules(Solution solution,
-         HashMap<String, ArrayList<Double>> thresholds, Map<String, Object> baseAppMap, Topology topology,
-         double hyst, QualityInformation requirements) {
+         HashMap<String, ArrayList<Double>> thresholds, Map<String, Object> baseAppMap, Topology topology, double hyst,
+         QualityInformation requirements) {
 
-      //for each module in the topology
-      for(String modName : topology.getModuleNamesIterator()){
+      // for each module in the topology
+      for (String modName : topology.getModuleNamesIterator()) {
          log.debug("Checking the reconfiguration thresholds for module: " + modName);
-         
-         //a module will have reconfiguration thesholds if: it can scale AND
-         //there were created reconfiguration thresholds OR the number of instances in the proposed solution was higher than one 
-        
-         if(topology.getModule(modName).canScale()){
-            //it can scale AND
-            
-            if(thresholds.containsKey(modName) && thresholds.get(modName).size()>0){
-               //there were created reconfiguration thresholds
-               addWorkloadAndPoolSizeBoundsForScalableModule(modName, solution, thresholds.get(modName).get(0), hyst, thresholds.get(modName).size(), baseAppMap);
-            }
-            else{
-               if(solution.getCloudInstancesForModule(modName) > 1){
-                  //the number of instances in the proposed solution was higher than one
-                  addWorkloadAndPoolSizeBoundsForScalableModule(modName, solution, requirements.getWorkload(), hyst, 0, baseAppMap);
+
+         // a module will have reconfiguration thesholds if: it can scale AND
+         // there were created reconfiguration thresholds OR the number of
+         // instances in the proposed solution was higher than one
+
+         if (topology.getModule(modName).canScale()) {
+            // it can scale AND
+
+            if (thresholds.containsKey(modName) && thresholds.get(modName).size() > 0) {
+               // there were created reconfiguration thresholds
+               addWorkloadAndPoolSizeBoundsForScalableModule(modName, solution, thresholds.get(modName).get(0), hyst,
+                     thresholds.get(modName).size(), baseAppMap);
+            } else {
+               if (solution.getCloudInstancesForModule(modName) > 1) {
+                  // the number of instances in the proposed solution was higher
+                  // than one
+                  addWorkloadAndPoolSizeBoundsForScalableModule(modName, solution, requirements.getWorkload(), hyst, 0,
+                        baseAppMap);
+               } else {
+                  log.debug("Module {}, even if it was scalable, hadn't thresholds or more than one instance", modName);
                }
-               else{
-                  log.debug("Module {}, even if it was scalable, hadn't thresholds or more than one instance",modName);
-               }
             }
-            
+
+         } else {
+            log.debug("Module {} was not scalable", modName);
          }
-         else{
-            log.debug("Module {} was not scalable",modName);
-         }
-         
-         
+
       }
-      
- 
+
    }
 
    private void addWorkloadAndPoolSizeBoundsForScalableModule(String modName, Solution solution, Double firstThreshold,
          double hyst, int maxNumExtraInstances, Map<String, Object> baseAppMap) {
-      
+
       // get number of instances in solution.
       int numInstances = solution.getCloudInstancesForModule(modName);
       // divide the first threshold by the number of instances. Thats the
@@ -293,13 +304,11 @@ public class OptimizerInitialDeployment {
       double lowerWklBound = upperWklBound * hyst;
       // maximum pool is the number of instances plus the size of
       // thresholds list
-      int maxPoolSize =maxNumExtraInstances + numInstances;
-      log.debug("Adding upperWkl={} lowerWkl={} poolsize={}",upperWklBound, lowerWklBound, maxPoolSize);
-      
-      YAMLoptimizerParser.addScalingPolicyToModule(modName, baseAppMap, lowerWklBound, upperWklBound, 1,
-            maxPoolSize);
+      int maxPoolSize = maxNumExtraInstances + numInstances;
+      log.debug("Adding upperWkl={} lowerWkl={} poolsize={}", upperWklBound, lowerWklBound, maxPoolSize);
 
-      
+      YAMLoptimizerParser.addScalingPolicyToModule(modName, baseAppMap, lowerWklBound, upperWklBound, 1, maxPoolSize);
+
    }
 
    private String showThresholds(HashMap<String, ArrayList<Double>> thresholds) {
@@ -389,8 +398,9 @@ public class OptimizerInitialDeployment {
       double perfGoodness = requirements.getResponseTime() / qualityAnalyzer
             .computePerformance(sol, topology, requirements.getWorkload(), cloudCharacteristics).getResponseTime();
 
-      log.debug("Create reconfiguration Thresholds method has finished its call to compute Performance with result {}",
-            perfGoodness);
+      log.debug(
+            "Create reconfiguration Thresholds method has finished its call to compute Performance with result {} because the computed response time was {}",
+            perfGoodness, qualityAnalyzer.getAllComputedQualities().getResponseTime());
 
       if ((requirements.existResponseTimeRequirement()) && (perfGoodness >= 1.0)) {
          // response time requirements are satisfied if perfGoodness>=1.0

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/Topology.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/Topology.java
@@ -26,10 +26,10 @@ import org.slf4j.LoggerFactory;
 
 public class Topology {
 
-   static Logger log = LoggerFactory.getLogger(Topology.class);
+   static Logger                 log = LoggerFactory.getLogger(Topology.class);
 
    private List<TopologyElement> modules;
-   private TopologyElement initialElement;
+   private TopologyElement       initialElement;
 
    public Topology() {
       modules = new ArrayList<TopologyElement>();
@@ -62,13 +62,14 @@ public class Topology {
    }
 
    public TopologyElement getInitialElement() {
-      //if the InitialElement attribute is set. Return it.
-      if(initialElement!=null){
+      // if the InitialElement attribute is set. Return it.
+      if (initialElement != null) {
          return initialElement;
       }
-      //The initial element was not set. We assume that The initial element is such one that is not called by
+      // The initial element was not set. We assume that The initial element is
+      // such one that is not called by
       // anyone.
-      
+
       for (TopologyElement pointed : modules) {
          boolean isInitial = true;
 
@@ -81,6 +82,7 @@ public class Topology {
          }
 
          if (isInitial) {
+            initialElement = pointed;
             return pointed;
          }
 
@@ -91,8 +93,8 @@ public class Topology {
       return null;
    }
 
-   public int indexOf(TopologyElement initialElement) {
-      return modules.indexOf(initialElement);
+   public int indexOf(TopologyElement element) {
+      return modules.indexOf(element);
    }
 
    public void replaceElementName(String modName, String newName) {
@@ -116,14 +118,15 @@ public class Topology {
    public void replaceElementsIndexes(TopologyElement element, int toIndex) {
       int targetIndex = modules.indexOf(element);
       if (log.isDebugEnabled()) {
-         if(modules==null){
+         if (modules == null) {
             log.warn("Modules in topology points to NULL");
          }
-         if(element==null){
+         if (element == null) {
             log.warn("Element to search in topology points to NULL");
          }
          log.debug("The topology consists of " + modules.size() + " modules. Replacing index " + toIndex + " with "
-               + targetIndex + ". The element name whose index was searched was " + element.getName() + "and the topology was composed of modules: " + toString());
+               + targetIndex + ". The element name whose index was searched was " + element.getName()
+               + "and the topology was composed of modules: " + toString());
       }
       TopologyElement replaced = modules.set(toIndex, element);
       modules.set(targetIndex, replaced);
@@ -138,6 +141,33 @@ public class Topology {
 
    public TopologyElement getElementIndex(int index) {
       return modules.get(index);
+   }
+
+   public boolean modulesHavePerformanceInformation() {
+
+      TopologyElement initial = getInitialElement();
+
+      return moduleOrDependenciesHavePerformanceInformationRecursive(initial);
+   }
+
+   /**
+    * @param element
+    * @return whether any among the input element or its dependencies (deep)
+    *         contain information required for the performance evaluation
+    */
+   private boolean moduleOrDependenciesHavePerformanceInformationRecursive(TopologyElement element) {
+
+      if (element.hasPerformanceInformation()) {
+         return true;
+      }
+
+      List<TopologyElementCalled> dependences = element.getDependences();
+      for (TopologyElementCalled elementCalled : dependences) {
+         if (moduleOrDependenciesHavePerformanceInformationRecursive(elementCalled.getElement())) {
+            return true;
+         }
+      }
+      return false;
    }
 
    public boolean contains(String elementName) {
@@ -216,14 +246,12 @@ public class Topology {
    }
 
    public void setInitialElementByElementName(String moduleName) {
-     if(moduleName==null){
-        initialElement=null;
-     }
-     else{
-        initialElement=getModule(moduleName);
-     }
-     
-      
+      if (moduleName == null) {
+         initialElement = null;
+      } else {
+         initialElement = getModule(moduleName);
+      }
+
    }
 
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/Topology.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/Topology.java
@@ -26,10 +26,10 @@ import org.slf4j.LoggerFactory;
 
 public class Topology {
 
-   static Logger                 log = LoggerFactory.getLogger(Topology.class);
+   static Logger log = LoggerFactory.getLogger(Topology.class);
 
    private List<TopologyElement> modules;
-   private TopologyElement       initialElement;
+   private TopologyElement initialElement;
 
    public Topology() {
       modules = new ArrayList<TopologyElement>();

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/TopologyElement.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/TopologyElement.java
@@ -75,6 +75,10 @@ public class TopologyElement implements Iterable<TopologyElementCalled> {
       return this.execTimeInPowerlessMachine;
    }
 
+   public boolean hasPerformanceInformation() {
+     return getDefaultExecutionTime()!=0.0;
+   }
+   
    public void addElementCalled(TopologyElement e) {
       TopologyElementCalled elementCalled = new TopologyElementCalled(e);
       dependences.add(elementCalled);
@@ -139,5 +143,7 @@ public class TopologyElement implements Iterable<TopologyElementCalled> {
       };
       return it;
    }
+
+
 
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/HillClimb.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/heuristics/HillClimb.java
@@ -17,7 +17,7 @@
 
 package eu.seaclouds.platform.planner.optimizer.heuristics;
 
-import java.util.ArrayList;
+
 import java.util.Arrays;
 
 import org.slf4j.Logger;

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
@@ -533,13 +533,15 @@ public class QualityAnalyzer {
          // Stop condition is the highest allowed cost or, if cost is not
          // specified, ten times the expected worklaod
 
-         log.trace("Creating threshold for workload above {}", limitWorkload);
+         log.info("Creating threshold for workload above {}", limitWorkload);
 
          limitWorkload = findWorkloadForWhichRespTimeIsExceeded(requirements.getResponseTime(), limitWorkload, mus,
                modifSol, topology, cloudCharacteristics);
+         log.info("Workload for which current topoloy will exceed the response time is {}", limitWorkload);
          // get highest utilization
          String moduleWithHighestUtilization = findHighestUtilizationModuleThatCanScale(limitWorkload, mus, modifSol,
                topology, cloudCharacteristics);
+         log.info("The bottleneck module for workload {} is {}", limitWorkload, moduleWithHighestUtilization);
 
          // put the value in the hashMap. "moduleWithHighestUtilization" may be
          // null
@@ -662,25 +664,22 @@ public class QualityAnalyzer {
       // Stop also if the highest allowed cost or, if cost is not specified, ten
       // times the expected workload
 
-      log.debug("checking if continue generating thresholds for: ");
+      log.info("checking if continue generating thresholds for: ");
 
       if (!existModulesToScaleOut) {
+         log.info("Nothing, there are not any module to scale out");
          return false;
       }
       if (requirements.existCostRequirement()) {
 
-         if (log.isDebugEnabled()) {
-            log.debug("  current cost: " + computeCost(sol, cloudCharacteristics) + " cost limit: "
-                  + requirements.getCostHour());
-         }
+         log.info("  current cost: {}  cost limit: {}", computeCost(sol, cloudCharacteristics),
+               requirements.getCostHour());
 
          return computeCost(sol, cloudCharacteristics) <= requirements.getCostHour();
       }
 
-      if (log.isDebugEnabled()) {
-         log.debug("  limitWorkload: " + limitWorkload + " current workload "
-               + (MAX_TIMES_WORKLOAD_FOR_THRESHOLDS * workload));
-      }
+      log.info("  limitWorkload: {} current workload {}", limitWorkload,
+            (MAX_TIMES_WORKLOAD_FOR_THRESHOLDS * workload));
 
       return limitWorkload <= (MAX_TIMES_WORKLOAD_FOR_THRESHOLDS * workload);
 

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import eu.seaclouds.platform.planner.optimizer.CloudOffer;
 import eu.seaclouds.platform.planner.optimizer.Solution;
 import eu.seaclouds.platform.planner.optimizer.SuitableOptions;
 import eu.seaclouds.platform.planner.optimizer.Topology;

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityAnalyzer.java
@@ -533,15 +533,15 @@ public class QualityAnalyzer {
          // Stop condition is the highest allowed cost or, if cost is not
          // specified, ten times the expected worklaod
 
-         log.info("Creating threshold for workload above {}", limitWorkload);
+         log.debug("Creating threshold for workload above {}", limitWorkload);
 
          limitWorkload = findWorkloadForWhichRespTimeIsExceeded(requirements.getResponseTime(), limitWorkload, mus,
                modifSol, topology, cloudCharacteristics);
-         log.info("Workload for which current topoloy will exceed the response time is {}", limitWorkload);
+         log.debug("Workload for which current topoloy will exceed the response time is {}", limitWorkload);
          // get highest utilization
          String moduleWithHighestUtilization = findHighestUtilizationModuleThatCanScale(limitWorkload, mus, modifSol,
                topology, cloudCharacteristics);
-         log.info("The bottleneck module for workload {} is {}", limitWorkload, moduleWithHighestUtilization);
+         log.debug("The bottleneck module for workload {} is {}", limitWorkload, moduleWithHighestUtilization);
 
          // put the value in the hashMap. "moduleWithHighestUtilization" may be
          // null
@@ -664,21 +664,21 @@ public class QualityAnalyzer {
       // Stop also if the highest allowed cost or, if cost is not specified, ten
       // times the expected workload
 
-      log.info("checking if continue generating thresholds for: ");
+      log.debug("checking if continue generating thresholds for: ");
 
       if (!existModulesToScaleOut) {
-         log.info("Nothing, there are not any module to scale out");
+         log.debug("Nothing, there are not any module to scale out");
          return false;
       }
       if (requirements.existCostRequirement()) {
 
-         log.info("  current cost: {}  cost limit: {}", computeCost(sol, cloudCharacteristics),
+         log.debug("  current cost: {}  cost limit: {}", computeCost(sol, cloudCharacteristics),
                requirements.getCostHour());
 
          return computeCost(sol, cloudCharacteristics) <= requirements.getCostHour();
       }
 
-      log.info("  limitWorkload: {} current workload {}", limitWorkload,
+      log.debug("  limitWorkload: {} current workload {}", limitWorkload,
             (MAX_TIMES_WORKLOAD_FOR_THRESHOLDS * workload));
 
       return limitWorkload <= (MAX_TIMES_WORKLOAD_FOR_THRESHOLDS * workload);

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityInformation.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/nfp/QualityInformation.java
@@ -49,6 +49,9 @@ public class QualityInformation {
       setResponseTimeSecs(resp / 1000.0);
    }
 
+   public void disableResponseTimeRequirement(){
+      this.respTime=0.0;
+   }
    public boolean existResponseTimeRequirement() {
       return respTime != 0.0;
    }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/TOSCAkeywords.java
@@ -21,6 +21,7 @@ public class TOSCAkeywords {
 
    public static final String TOPOLOGY_TEMPLATE               = "topology_template";
    public static final String NODE_TEMPLATE                   = "node_templates";
+   public static final String DESCRIPTION                     = "description";
    public static final String NODE_TYPES                      = "node_types";
    public static final String SUITABLE_SERVICES               = "suitableServices";
    public static final String MODULE_REQUIREMENTS             = "requirements";
@@ -119,6 +120,6 @@ public class TOSCAkeywords {
    public static final String TYPE_OF_HARDWARE_ID = "string";
    public static final boolean IS_HARDWARE_PROPERTY_REQUIRED= false;
    
-   public static final String CLOUD_OFFER_PROVIDER_NAME_SEPARATOR = "\\.";
+   public static final String  CLOUD_OFFER_PROVIDER_NAME_SEPARATOR               = "\\.";
 
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLgroupsOptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLgroupsOptimizerParser.java
@@ -159,7 +159,6 @@ public class YAMLgroupsOptimizerParser {
 
    public static List<String> getListDependentGroupsOfModule(String moduleName, Map<String, Object> groups) {
 
-      Map<String, Object> moduleDependencies = null;
 
       Map<String, Object> dependenciesInfoOfGroupOfModule = YAMLgroupsOptimizerParser
             .getDependenciesInfoOfMemberName(moduleName, groups);

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLmodulesOptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLmodulesOptimizerParser.java
@@ -148,7 +148,8 @@ public class YAMLmodulesOptimizerParser {
    /**
     * @param moduleName
     * @param groups
-    * @return the name of the benchmark platform where the module was tested for execution time
+    * @return the name of the benchmark platform where the module was tested for
+    *         execution time
     */
    @SuppressWarnings("unchecked")
    public static String getMeasuredPerformanceHost(String moduleName, Map<String, Object> groups) {
@@ -158,9 +159,7 @@ public class YAMLmodulesOptimizerParser {
       Map<String, Object> qoSinfoOfGroupOfModule = YAMLgroupsOptimizerParser.getQoSinfoOfMemberName(moduleName, groups);
 
       if (qoSinfoOfGroupOfModule == null) {
-         if (log.isDebugEnabled()) {
-            log.debug("There has not been found info of QoS for module called " + moduleName);
-         }
+         log.debug("There has not been found info of QoS for module called {}", moduleName);
          return null;
       }
 
@@ -170,9 +169,9 @@ public class YAMLmodulesOptimizerParser {
 
       // not found There were qos properties but not the information of teh
       // machine tested
-      if (log.isDebugEnabled()) {
-         log.debug("Module had qos info but it did not contain information of the platform where it was executed");
-      }
+
+      log.debug("Module had qos info but it did not contain information of the platform where it was executed");
+
       return null;
    }
 
@@ -232,7 +231,7 @@ public class YAMLmodulesOptimizerParser {
       // that are members of each of the groups on which
       // the group of modulename belongs
 
-      ArrayList<String> dependentModules = new ArrayList<String>();
+      List<String> dependentModules = new ArrayList<String>();
 
       List<String> dependentGroups = (List<String>) YAMLgroupsOptimizerParser.getListDependentGroupsOfModule(moduleName,
             groups);
@@ -357,24 +356,42 @@ public class YAMLmodulesOptimizerParser {
 
    public static boolean getScalabilityCapabilitiesOfModule(Map<String, Object> modules, String elementName) {
       try {
-         Map<String, Object> moduleInfo = (Map<String, Object>) modules.get(elementName);
-         Map<String, Object> moduleProperties = (Map<String, Object>) moduleInfo
-               .get(TOSCAkeywords.MODULE_PROPERTIES_TAG);
-         boolean moduleCanScale = (boolean) moduleProperties.get(TOSCAkeywords.MODULE_AUTOSCALE_PROPERTY);
-         return moduleCanScale;
-      } catch (Exception e) {
+         Map<String, Object> moduleInfo;
+         if (modules.containsKey(elementName)) {
+            moduleInfo = (Map<String, Object>) modules.get(elementName);
+         } else {
+            // not specified the scalability. Default value for not specified is
+            // true;
+            return true;
+         }
+
+         Map<String, Object> moduleProperties;
+         if (moduleInfo.containsKey(TOSCAkeywords.MODULE_PROPERTIES_TAG)) {
+            moduleProperties = (Map<String, Object>) moduleInfo.get(TOSCAkeywords.MODULE_PROPERTIES_TAG);
+         } else {
+            // not specified the scalability. Default value for not specified is
+            // true;
+            return true;
+         }
+         if(moduleProperties.containsKey(TOSCAkeywords.MODULE_AUTOSCALE_PROPERTY)){
+            return (boolean) moduleProperties.get(TOSCAkeywords.MODULE_AUTOSCALE_PROPERTY);
+         }else {
+            // not specified the scalability. Default value for not specified is
+            // true;
+            return true;
+         }
+         
+      } catch (ClassCastException e) {
          // Some part did not work looking in the definition of scaling.
          // Probably because it was not defined.
-         if (log.isDebugEnabled()) {
-            log.debug("For module " + elementName
-                  + " it was not found information in the AAM regarding its possibility to scale");
-         }
+         log.debug("For module {} it was not found information in the AAM regarding its possibility to scale",
+               elementName);
+
          // Returning the default value "true" for seeing policies generated
       }
       return true;
    }
 
-   
    /**
     * @param moduleName
     * @param modulesMap
@@ -397,9 +414,9 @@ public class YAMLmodulesOptimizerParser {
       return null;
    }
 
-   
    /**
-    * @param moduleInfo (information of the module, excluding the name of the module)
+    * @param moduleInfo
+    *           (information of the module, excluding the name of the module)
     * @return The type declared in the node template passed as parameter
     */
    public static String getModuleTypeFromModuleInfo(Map<String, Object> moduleInfo) {
@@ -410,11 +427,11 @@ public class YAMLmodulesOptimizerParser {
       }
    }
 
-   
    /**
     * @param modulesMap
     * @param moduleName
-    * @return the information of the node_template with key moduleName (the key is included)
+    * @return the information of the node_template with key moduleName (the key
+    *         is included)
     */
    public static Entry<String, Object> getModuleInfoFromModulesMap(Map<String, Object> modulesMap, String moduleName) {
       if (modulesMap.containsKey(moduleName)) {

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLmodulesOptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLmodulesOptimizerParser.java
@@ -30,6 +30,7 @@ import eu.seaclouds.platform.planner.optimizer.nfp.QualityInformation;
 //Version of September 2015
 public class YAMLmodulesOptimizerParser {
 
+   private static final boolean DEFAULT_SCALABILITY = false;
    static Logger log = LoggerFactory.getLogger(YAMLmodulesOptimizerParser.class);
 
    public static boolean moduleHasModuleRequirements(String moduleName, Map<String, Object> groups) {
@@ -361,8 +362,8 @@ public class YAMLmodulesOptimizerParser {
             moduleInfo = (Map<String, Object>) modules.get(elementName);
          } else {
             // not specified the scalability. Default value for not specified is
-            // true;
-            return true;
+            // DEFAUT_SCALABILITY;
+            return DEFAULT_SCALABILITY;
          }
 
          Map<String, Object> moduleProperties;
@@ -370,15 +371,15 @@ public class YAMLmodulesOptimizerParser {
             moduleProperties = (Map<String, Object>) moduleInfo.get(TOSCAkeywords.MODULE_PROPERTIES_TAG);
          } else {
             // not specified the scalability. Default value for not specified is
-            // true;
-            return true;
+            // DEFAUT_SCALABILITY;
+            return DEFAULT_SCALABILITY;
          }
          if(moduleProperties.containsKey(TOSCAkeywords.MODULE_AUTOSCALE_PROPERTY)){
             return (boolean) moduleProperties.get(TOSCAkeywords.MODULE_AUTOSCALE_PROPERTY);
          }else {
             // not specified the scalability. Default value for not specified is
-            // true;
-            return true;
+            // DEFAUT_SCALABILITY;
+            return DEFAULT_SCALABILITY;
          }
          
       } catch (ClassCastException e) {
@@ -386,10 +387,10 @@ public class YAMLmodulesOptimizerParser {
          // Probably because it was not defined.
          log.debug("For module {} it was not found information in the AAM regarding its possibility to scale",
                elementName);
-
-         // Returning the default value "true" for seeing policies generated
+         
       }
-      return true;
+   // Returning the default value // DEFAUT_SCALABILITY 
+      return DEFAULT_SCALABILITY;
    }
 
    /**

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
@@ -483,7 +483,8 @@ public class YAMLoptimizerParser {
       for (Map.Entry<String, Object> module : modules.entrySet()) {
          if (!topology.contains(module.getKey())) {
             // Add module to topology
-            log.debug("DisconnectedModules method found that element {} was not included in the topology. Adding it", module.getKey());
+            log.debug("DisconnectedModules method found that element {} was not included in the topology. Adding it",
+                  module.getKey());
             TopologyElement newelement = getNewTopologyElementCharacteristics(module.getKey(), groups,
                   benchmarkPlatforms, modules);
 
@@ -582,14 +583,17 @@ public class YAMLoptimizerParser {
          Map<String, CloudOffer> benchmarkPlatforms, Map<String, Object> modules) {
       TopologyElement newelement = new TopologyElement(elementName);
 
-      double hostPerformance = benchmarkPlatforms
-            .get(YAMLmodulesOptimizerParser.getMeasuredPerformanceHost(elementName, groups)).getPerformance();
-
-      if (log.isDebugEnabled()) {
-         log.debug("Found performance of benchmark platform "
-               + YAMLmodulesOptimizerParser.getMeasuredPerformanceHost(elementName, groups) + "=" + benchmarkPlatforms
-                     .get(YAMLmodulesOptimizerParser.getMeasuredPerformanceHost(elementName, groups)).getPerformance());
+      log.debug("Creating topologyElement for module name:{} ", elementName);
+      String benchmarkedHostName = YAMLmodulesOptimizerParser.getMeasuredPerformanceHost(elementName, groups);
+      double hostPerformance = 0.0;
+      if (benchmarkedHostName != null) {
+         hostPerformance = benchmarkPlatforms.get(benchmarkedHostName).getPerformance();
+         log.debug("Found performance of benchmark platform {}={}", benchmarkedHostName, hostPerformance);
+      } else {
+         log.debug("Not found benchmark platform for element {} . Performance of host is: {} ", elementName,
+               hostPerformance);
       }
+
       boolean elementCanScale = YAMLmodulesOptimizerParser.getScalabilityCapabilitiesOfModule(modules, elementName);
 
       newelement.setExecTimeMillis(
@@ -821,6 +825,22 @@ public class YAMLoptimizerParser {
    public static void addComputeTypeToTypes(Map<String, Object> appMap) {
       YAMLtypesOptimizerParser.addComputeType(YAMLoptimizerParser.getTypesMapFromAppMap(appMap));
 
+   }
+
+   public static String getModelDescriptionFromAppMap(Map<String, Object> appMap) {
+
+      if (appMap.containsKey(TOSCAkeywords.DESCRIPTION)) {
+         return (String) appMap.get(TOSCAkeywords.DESCRIPTION);
+      } else {
+         log.info("It has not been found the information of '{}'", TOSCAkeywords.DESCRIPTION);
+      }
+      return "";
+   }
+
+   public static void setModelDescriptionOfAppMap(Map<String, Object> appMap, String descriptoinInfo) {
+     
+      appMap.put(TOSCAkeywords.DESCRIPTION, descriptoinInfo);
+      
    }
 
 }

--- a/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
+++ b/planner/optimizer/optimizer-core/src/main/java/eu/seaclouds/platform/planner/optimizer/util/YAMLoptimizerParser.java
@@ -832,7 +832,7 @@ public class YAMLoptimizerParser {
       if (appMap.containsKey(TOSCAkeywords.DESCRIPTION)) {
          return (String) appMap.get(TOSCAkeywords.DESCRIPTION);
       } else {
-         log.info("It has not been found the information of '{}'", TOSCAkeywords.DESCRIPTION);
+         log.info("It has not been found the information of '{}' in the model", TOSCAkeywords.DESCRIPTION);
       }
       return "";
    }

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/AbstractTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/AbstractTest.java
@@ -39,23 +39,7 @@ public class AbstractTest {
    protected static Logger log;
 
    public void openInputFiles() {
-      final String dir = System.getProperty("user.dir");
-      log.debug("Trying to open files: current executino dir = " + dir);
-
-      try {
-         appModel = filenameToString(TestConstants.APP_MODEL_FILENAME);
-      } catch (IOException e) {
-         log.error("File for APPmodel not found");
-         e.printStackTrace();
-      }
-
-      try {
-         suitableCloudOffer = filenameToString(TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
-      } catch (IOException e) {
-         log.error("File for Cloud Offers not found");
-         e.printStackTrace();
-      }
-      
+      openInputFiles(TestConstants.APP_MODEL_FILENAME,TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);      
    }
    
    public void openInputFiles(String appmodel, String cloudOffers) {

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015NoQoSinfoInAAMTest.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/OptimizerTOSCADecember2015NoQoSinfoInAAMTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2015 SeaClouds
+ * Contact: SeaClouds
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package eu.seaclouds.platform.planner.optimizerTest;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import eu.seaclouds.platform.planner.optimizer.Optimizer;
+import eu.seaclouds.platform.planner.optimizer.heuristics.SearchMethodName;
+import eu.seaclouds.platform.planner.optimizer.util.TOSCAkeywords;
+import eu.seaclouds.platform.planner.optimizer.util.YAMLoptimizerParser;
+
+public class OptimizerTOSCADecember2015NoQoSinfoInAAMTest extends AbstractTest {
+
+   private static final String TEST_CHARACTERISTIC            = " AAM WITHOUT QoSInfo ";
+   private static final String OUTPUT_FILENAME_CHARACTERISTIC = "NoQoSinfo";
+
+   @BeforeClass
+   public void createObjects() {
+
+      log = LoggerFactory.getLogger(OptimizerTOSCADecember2015NoQoSinfoInAAMTest.class);
+
+      log.info("Starting TEST optimizer for the TOSCA syntax of September 2015 Of an " + TEST_CHARACTERISTIC);
+      openInputFiles(TestConstants.APP_MODEL_FILENAME_NO_QOSINFO_NO_AUTOSCALE,
+            TestConstants.CLOUD_OFFER_FILENAME_IN_JSON);
+   }
+
+   @Test(enabled = true)
+   public void testNoQoSinTemplateBlind() {
+
+      log.info("=== TEST for SOLUTION GENERATION of BLIND optimizer " + TEST_CHARACTERISTIC
+            + " - STARTED (syntax December 2015)===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.BLINDSEARCH);
+
+      executeAndSave(appModel, suitableCloudOffer, SearchMethodName.BLINDSEARCH);
+
+      log.info("=== TEST for SOLUTION GENERATION  of BLIND optimizer " + TEST_CHARACTERISTIC
+            + "   - FINISEHD ===");
+
+   }
+
+   @Test(enabled = true)
+   public void testNoQoSinTemplateHillClimb() {
+
+      log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer" + TEST_CHARACTERISTIC + "   - STARTED ===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.HILLCLIMB);
+
+      executeAndSave(appModel, suitableCloudOffer, SearchMethodName.HILLCLIMB);
+
+      log.info("=== TEST for SOLUTION GENERATION of HILLCLIMB optimizer " + TEST_CHARACTERISTIC
+            + "   FINISEHD ===");
+
+   }
+
+   @Test(enabled = true)
+   public void testNoQoSinTemplateAnneal() {
+
+      log.info("=== TEST for SOLUTION GENERATION of ANNEAL optimizer" + TEST_CHARACTERISTIC + "   - STARTED ===");
+
+      optimizer = new Optimizer(TestConstants.NUM_PLANS_TO_GENERATE, SearchMethodName.ANNEAL);
+
+      executeAndSave(appModel, suitableCloudOffer, SearchMethodName.ANNEAL);
+
+      log.info("=== TEST for SOLUTION GENERATION  of ANNEAL optimizer " + TEST_CHARACTERISTIC
+            + "   - FINISEHD ===");
+
+   }
+
+   public void executeAndSave(String appModel2, String suitableCloudOffer2, SearchMethodName methodName) {
+      String[] arrayAdp = optimizer.optimize(appModel, suitableCloudOffer, null);
+      checkNonExistenceOfAutoscalingPolicies(arrayAdp);
+      for (int adpnum = 0; adpnum < arrayAdp.length; adpnum++) {
+
+         saveFile(TestConstants.OUTPUT_FILENAME + methodName + OUTPUT_FILENAME_CHARACTERISTIC + adpnum + ".yaml",
+               arrayAdp[adpnum]);
+      }
+
+   }
+
+   private void checkNonExistenceOfAutoscalingPolicies(String[] arrayAdp) {
+
+      for (int i = 0; i < arrayAdp.length; i++) {
+         Map<String, Object> adpGroupsMap = YAMLoptimizerParser.getGroupMapFromAppMap(YAMLoptimizerParser.getMAPofAPP(arrayAdp[i]));
+              
+
+         Assert.assertFalse("ERROR: some module had autoscaling policy when it shouldn't. ADP" + i + " with content: " + arrayAdp[i],
+               someGroupHasAutoscaling(adpGroupsMap));
+         ;
+      }
+
+   }
+
+   @SuppressWarnings("unchecked")
+   private boolean someGroupHasAutoscaling(Map<String, Object> adpGroupsMap) {
+      
+      for(Map.Entry<String,Object> group : adpGroupsMap.entrySet()){
+         //check if a group had austoscaling
+         if(groupHasAutoscaling((Map<String,Object>)group.getValue())){return true;}
+      }
+      
+      return false;
+   }
+
+   private boolean groupHasAutoscaling(Map<String, Object> groupInfo) {
+     
+      @SuppressWarnings("unchecked")
+      List<Map<String,Object>> policies = (List<Map<String,Object>>) groupInfo.get(TOSCAkeywords.GROUP_ELEMENT_POLICY_TAG);
+      for(Map<String,Object> policy : policies){
+         //check if some of the policies was autoscaling
+         if(policy.containsKey(TOSCAkeywords.AUTOSCALING_TAG)){
+            return true;
+         }
+      }
+      return false;
+   }
+
+   
+  
+   @AfterClass
+   public void testFinishced() {
+      log.info("===== ALL TESTS FOR OPTIMIZER FOR " + TEST_CHARACTERISTIC + " USING DECEMBER 2015 TOSCA FINISHED ===");
+   }
+
+}

--- a/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/TestConstants.java
+++ b/planner/optimizer/optimizer-core/src/test/java/eu/seaclouds/platform/planner/optimizerTest/TestConstants.java
@@ -42,5 +42,7 @@ public abstract class TestConstants {
 
    public static final String APP_MODEL_FILENAME_MULTIPLE_INPUT_POINT = "./src/test/resources/aam_atos_case_studyDisconnected26Feb16.yml";
    public static final String CLOUD_OFFER_FILENAME_IN_JSON_ATOS_7_MODULES = "./src/test/resources/mmOutputExampleForTestingAtosDisconnectedGraph.json";
+
+   public static final String APP_MODEL_FILENAME_NO_QOSINFO_NO_AUTOSCALE = "./src/test/resources/aam_atos_case_studyNoQoSInfoNoAutoscale26Feb16.yml";
    
 }

--- a/planner/optimizer/optimizer-core/src/test/resources/aam_atos_case_studyNoQoSInfoNoAutoscale26Feb16.yml
+++ b/planner/optimizer/optimizer-core/src/test/resources/aam_atos_case_studyNoQoSInfoNoAutoscale26Feb16.yml
@@ -1,0 +1,107 @@
+tosca_definitions_version: tosca_simple_yaml_1_0_0_wd03
+description: 3tier example
+imports:
+- tosca-normative-types:1.0.0.wd03-SNAPSHOT
+topology_template:
+  node_templates:
+    www:
+      type: sc_req.www
+      properties:
+        language: JAVA
+        location: DYNAMIC
+        location_option: FOLLOW_SUN
+        autoscale: false
+      requirements:
+      - endpoint: webservices
+    webservices:
+      type: sc_req.webservices
+      properties:
+        language: JAVA
+        location: STATIC
+        location_option: EUROPE
+        autoscale: false
+        java_version:
+          constraints:
+          - greater_or_equal: '7'
+          - less_or_equal: '8'
+      requirements:
+      - endpoint: db1
+    db1:
+      type: sc_req.db1
+      properties:
+        autoscale: false
+        mysql_version:
+          constraints:
+          - greater_or_equal: '5.0'
+          - less_or_equal: '5.6'
+node_types:
+  sc_req.www:
+    derived_from: seaclouds.nodes.webapp.tomcat.TomcatServer
+    properties:
+      java_support:
+        constraints:
+        - equal: true
+      tomcat_support:
+        constraints:
+        - equal: true
+      java_version:
+        constraints:
+        - greater_or_equal: '7'
+        - less_or_equal: '8'
+      resource_type:
+        constraints:
+        - equal: platform
+  sc_req.webservices:
+    derived_from: seaclouds.nodes.SoftwareComponent
+    properties:
+      num_cpus:
+        constraints:
+        - greater_or_equal: '4'
+      disk_size:
+        constraints:
+        - greater_or_equal: '256'
+      resource_type:
+        constraints:
+        - equal: compute
+  sc_req.db1:
+    derived_from: seaclouds.nodes.database.mysql.MySqlNode
+    properties:
+      mysql_support:
+        constraints:
+        - equal: true
+      mysql_version:
+        constraints:
+        - greater_or_equal: '5.0'
+        - less_or_equal: '5.6'
+groups:
+  operation_www:
+    members:
+    - www
+    policies:
+    - dependencies:
+        operation_webservices: '2'
+    - AppQoSRequirements:
+        response_time:
+          less_than: 2000.0 ms
+        availability:
+          greater_than: 0.98
+        cost:
+          less_or_equal: 2000.0 euros_per_month
+        workload:
+          less_or_equal: 50.0 req_per_min
+  operation_webservices:
+    members:
+    - webservices
+    policies:
+    - dependencies:
+        operation_db1: '1'
+    - QoSRequirements:
+        AverageResponseTime:
+          less_than: 1000.0 ms
+        AppAvailable:
+          greater_than: 99.8
+  operation_db1:
+    members:
+    - db1
+    policies:
+    - dependencies: {}


### PR DESCRIPTION
With this PR the optimizer reads the `autoscale` value from AAM even if the AAM does not contain  `QoSinfo` . Tests for this case have been added. 

Before this PR, when it was found the lack of the required quality information `QoSinfo` the `autoscale` value was not read but it took the default value of `true`