### PR TITLE
Fixes #275: Location not considered in matchmaker

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-forms.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor-forms.js
@@ -77,9 +77,10 @@ var EditorForms = (function() {
 
     var location_static_options = {
         "": "",
-        "EUROPE": "Europe",
-        "AMERICA": "America",
-        "ASIA": "Asia"
+        "Europe": "Europe",
+        "America": "America",
+        "Asia": "Asia",
+        "Oceania": "Oceania"
     };
 
 

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/Translator.java
@@ -127,7 +127,9 @@ public class Translator {
         
         
         /*
-         * If PaaS, set *_support for software requirements: language, container, category
+         * If PaaS, 
+         * - set *_support for software requirements: language, container, category
+         * - set location constraint if set to static
          */
         if (isPlatformEligible(dnode)) {
             /*
@@ -150,11 +152,16 @@ public class Translator {
                     moduleType.addSupportItemConstraintProperty(supportItem + "_support");
                 }
             }
+            if (DNode.Locations.STATIC.equals(dnode.getLocation())) {
+                Constraint constraint = buildContinentConstraint(dnode.getLocationOption());
+                moduleType.addConstrainedProperty("continent", constraint);
+            }
         }
         /*
          * If IaaS, 
          *   - set location, disk size, mem size in node_type
          *   - set language, category, versions in node_template
+         *   - set location constraint if set to static
          */
         if (isComputeEligible(dnode)) {
             if (!"".equals(dnode.getNumCpus())) {
@@ -164,6 +171,10 @@ public class Translator {
             if (!"".equals(dnode.getDiskSize())) {
                 Constraint constraint = buildGreaterEqualsConstraint(dnode.getDiskSize());
                 moduleType.addConstrainedProperty("disk_size", constraint);
+            }
+            if (DNode.Locations.STATIC.equals(dnode.getLocation())) {
+                Constraint constraint = buildContinentConstraint(dnode.getLocationOption());
+                moduleType.addConstrainedProperty("continent", constraint);
             }
         }
         /*
@@ -336,6 +347,12 @@ public class Translator {
     
     private Constraint buildGreaterEqualsConstraint(String threshold) {
         Constraint result = new Constraint(Constraint.Names.GE, threshold);
+        
+        return result;
+    }
+    
+    private Constraint buildContinentConstraint(String continent) {
+        Constraint result = new Constraint(Constraint.Names.EQ, continent);
         
         return result;
     }

--- a/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DNode.java
+++ b/planner/aamwriter/src/main/java/eu/seaclouds/platform/planner/aamwriter/modeldesigner/DNode.java
@@ -56,6 +56,11 @@ public class DNode {
         public static final String TOMCAT = "webapp.tomcat.TomcatServer";
         public static final String TOMCAT8 = "webapp.tomcat.Tomcat8Server";
     }
+
+    public static final class Locations {
+        public static final String STATIC = "STATIC";
+        public static final String DYNAMIC = "DYNAMIC";
+    }
     
     public static final DNode NOT_FOUND = new DNode("[null]", "[null]");
 
@@ -77,6 +82,8 @@ public class DNode {
     private String benchmarkPlatform;
     private List<Map<String, String>> qos;
     private boolean frontend;
+    private String location;
+    private String locationOption;
 
     public DNode(JSONObject jnode, DGraph graph) {
         this.graph = graph;
@@ -110,6 +117,8 @@ public class DNode {
         benchmarkPlatform = extractStringFromMap("benchmark_platform", map);
         qos = (List) extractQosFromMap("qos", map);
         frontend = extractBooleanFromMap("frontend", map);
+        location = extractStringFromMap("location", map);
+        locationOption = extractStringFromMap("location_option", map);
         return map;
     }
     
@@ -260,5 +269,13 @@ public class DNode {
             result = (this.graph.getFrontendNode() == this);
         }
         return result;
+    }
+    
+    public String getLocation() {
+        return location;
+    }
+    
+    public String getLocationOption() {
+        return locationOption;
     }
 }

--- a/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/TranslatorTest.java
+++ b/planner/aamwriter/src/test/java/eu/seaclouds/platform/planner/aamwriter/TranslatorTest.java
@@ -32,6 +32,7 @@ import eu.seaclouds.platform.planner.aamwriter.modelaam.Constraint;
 import eu.seaclouds.platform.planner.aamwriter.modelaam.Policy;
 import eu.seaclouds.platform.planner.aamwriter.modeldesigner.DGraph;
 import eu.seaclouds.platform.planner.aamwriter.modeldesigner.DLink;
+import eu.seaclouds.platform.planner.aamwriter.modeldesigner.DNode;
 import static org.testng.AssertJUnit.*;
 
 @SuppressWarnings({"unused", "rawtypes", "unchecked"})
@@ -296,6 +297,25 @@ public class TranslatorTest {
         }
     }
     
+    @Test
+    public void testLocationConstraint() {
+        
+        for (DNode n : graph.getNodes()) {
+            Map<String, Object> nodeType = nodeTypes.get("sc_req." + n.getName());
+            if (DNode.Locations.STATIC.equals(n.getLocation())) {
+                List<Map> constraints = getConstraints(nodeType, "continent");
+                assertNotNull(constraints);
+                assertTrue(constraints.size() > 0);
+                
+                String string = "equal";
+                Map constraint = searchFirstInArray(constraints, string);
+
+                assertNotNull(constraint);
+                assertEquals(n.getLocationOption(), constraint.get(string));
+            }
+        }
+    }
+    
     private Object getProperty(Map<String, Object> nodeTemplate, String propertyName) {
         Map properties = (Map)nodeTemplate.get("properties");
         Object actual = properties.get(propertyName);
@@ -387,6 +407,9 @@ public class TranslatorTest {
     private List<Map> getConstraints(Map<String, Object> m, String propertyName) {
         Map<String, Map> properties = (Map)m.get("properties");
         Map<String, List> property = properties.get(propertyName);
+        if (property == null) {
+            return null;
+        }
         List<Map> constraints = property.get("constraints");
         
         return constraints;

--- a/planner/aamwriter/src/test/resources/translator.json
+++ b/planner/aamwriter/src/test/resources/translator.json
@@ -69,6 +69,9 @@
                 "db_name": "<db_name>",
                 "db_user": "<db_user>",
                 "db_password": "<db_password>",
+                "location": "STATIC",
+                "location_option": "AMERICA",
+                "infrastructure": "platform",
             }
         },
         {


### PR DESCRIPTION
The location was not properly handled in the AAMWriter.

Now, the format in the AAM is (e.g.):
```
  sc_req.www:
    derived_from: seaclouds.nodes.php.httpd.PhpHttpdServer
    properties:
      resource_type:
        constraints:
        - equal: compute
      continent:
        constraints:
        - equal: Europe
```
This also changes the continent values to the right ones expected by the
matchmaker.