### PR TITLE
Fixes jumping topology on status screen.

### DIFF
--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/angular-topology-editor.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/angular-topology-editor.js
@@ -119,10 +119,19 @@
                         scope.canvas.init(uniqid, canvasOptions);
                         Status.init(scope.canvas);
 
+                        var currentAppId = "";
                         scope.$watch('topology', function (newValue) {
-                            Status.fromjson(scope.topology);
+                            if (currentAppId !== newValue.applicationId) {
+                                Status.fromjson(scope.topology);
+                                currentAppId = newValue.applicationId;
+                            }
+                            for (var i = 0; i < newValue.nodes.length; i++)
+                            {
+                                scope.canvas.getnodebyname(newValue.nodes[i].name).properties.status = newValue.nodes[i].properties.status;
+                            }
                             scope.canvas.restart();
                         });
+                        
                     }
 
                     $timeout(function () {

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.css
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/editor.css
@@ -15,7 +15,7 @@ circle.node.starting{
     stroke-dasharray: 5px;
 }
 
-circle.node.on-fire{
+circle.node.on_fire{
     stroke: #F33F3F;
 }
 

--- a/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/topology-editor-utils.js
+++ b/dashboard/src/main/resources/webapp/static/lib/angular-topology-editor/topology-editor-utils.js
@@ -59,6 +59,7 @@ var TopologyEditorUtils = (function() {
                 })
             }
         }
+        parentTopology.applicationId = brooklynEntity.applicationId;
         return parentTopology;
     }
 


### PR DESCRIPTION
Status.fromjson recreates() the whole topology structure. This commit
calls Status.fromjson only when the application changes.

TODO: the new code may update other properties than status (e.g., module
urls).