### PR TITLE
Feature/adding seaclouds dc to catalog

### DIFF
--- a/byon/files/seaclouds-catalog.bom
+++ b/byon/files/seaclouds-catalog.bom
@@ -409,6 +409,55 @@ brooklyn.catalog:
             enricher.targetSensor: $brooklyn:sensor("main.uri")
             enricher.targetValue: $brooklyn:formatString("http://%s:%s", $brooklyn:attributeWhenReady("host.address"), $brooklyn:config("http.port"))
 
+  - id: seaclouds-data-collector
+    name: SeaCloudsDc
+    description: SeaClouds Data Collector 
+    item:
+      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+      id: seacloudsdc
+      name: SeaClouds Data Collector
+
+      brooklyn.config:
+        runtimeFiles:
+          https://oss.sonatype.org/content/repositories/snapshots/eu/seaclouds-project/monitor/seaclouds-data-collector/1.1.0-SNAPSHOT/seaclouds-data-collector-1.1.0-20160421.085909-4.jar : seaclouds-dc.jar
+        http.port: 8176
+
+      shell.env:
+        SEACLOUDS_DC_PORT: $brooklyn:config("http.port")
+        MANAGER_IP: $brooklyn:component("monitor-manager").attributeWhenReady("host.address")
+        MANAGER_PORT: $brooklyn:component("monitor-manager").config("monitor.manager.port")
+        DC_SYNC_PERIOD: "10"
+        RESOURCES_KEEP_ALIVE_PERIOD: "25"
+
+      provisioning.properties:
+        osFamily: ubuntu
+        required.ports:
+        - 8176
+
+      launch.command: |
+        sudo apt-get update -y
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated tzdata openjdk-7-jdk wget curl
+        tee ./config.yaml  <<EOF
+        server:
+          type: simple
+          applicationContextPath: /
+          connector:
+            type: http
+            port: ${SEACLOUDS_DC_PORT}
+        manager_ip: ${MANAGER_IP}
+        manager_port: ${MANAGER_PORT}
+        dc_sync_period: ${DC_SYNC_PERIOD}
+        resources_keep_alive_period: ${RESOURCES_KEEP_ALIVE_PERIOD}
+        EOF
+
+        nohup java -jar seaclouds-dc.jar server ./config.yaml > seaclouds-dc.log 2>&1 &
+        echo $! > $PID_FILE
+
+      checkRunning.command: |
+        ps auxw | grep seaclouds-dc | grep -v grep > /dev/null
+
+      stop.command: |
+        sudo kill $(sudo lsof -t -i:8176)
 
   - id: seaclouds-platform-on-byon
     name: "SeaClouds Platform"
@@ -489,6 +538,10 @@ brooklyn.catalog:
           influxdb.config.db.name: tower4clouds
           influxdb.config.db.password: seaclouds
         install.latch: $brooklyn:component("discoverer").attributeWhenReady("service.isUp")
+      - type: seaclouds-data-collector
+        id: seaclouds-dc
+        name: seaclouds-dc
+        install.latch: $brooklyn:component("monitor-manager").attributeWhenReady("service.isUp")
       - type: seaclouds-discoverer
         name: seaclouds-discoverer
         id: discoverer
@@ -572,6 +625,10 @@ brooklyn.catalog:
         brooklyn.config:
           influxdb.config.db.name: tower4clouds
           influxdb.config.db.password: seaclouds
+      - type: seaclouds-data-collector
+        id: seaclouds-dc
+        name: seaclouds-dc
+        install.latch: $brooklyn:component("monitor-manager").attributeWhenReady("service.isUp")
       - type: seaclouds-discoverer
         name: seaclouds-discoverer
         id: discoverer

--- a/byon/files/seaclouds-catalog.bom
+++ b/byon/files/seaclouds-catalog.bom
@@ -453,6 +453,28 @@ brooklyn.catalog:
         nohup java -jar seaclouds-dc.jar server ./config.yaml > seaclouds-dc.log 2>&1 &
         echo $! > $PID_FILE
 
+      post.launch.command: |
+        curl -X POST http://localhost:$MANAGER_PORT/v1/monitoring-rules -d '
+          <monitoringRules xmlns="http://www.modaclouds.eu/xsd/1.0/monitoring_rules_schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.modaclouds.eu/xsd/1.0/monitoring_rules_schema">
+              <monitoringRule id="internalComponentRTRule" timeStep="2" timeWindow="2">
+                  <monitoredTargets>
+                      <monitoredTarget class="Method"/>
+                  </monitoredTargets>
+                  <collectedMetric metricName="EffectiveResponseTime">
+                      <parameter name="samplingProbability">1</parameter>
+                  </collectedMetric>
+                  <metricAggregation groupingClass="InternalComponent" aggregateFunction="Average"/>
+                  <actions>
+                      <action name="OutputMetric">
+                          <parameter name="metric">AverageResponseTimeInternalComponent</parameter>
+                          <parameter name="value">METRIC</parameter>
+                          <parameter name="resourceId">ID</parameter>
+                      </action>
+                  </actions>
+              </monitoringRule>
+          </monitoringRules>
+        '
+
       checkRunning.command: |
         ps auxw | grep seaclouds-dc | grep -v grep > /dev/null
 
@@ -513,8 +535,8 @@ brooklyn.catalog:
         name: seaclouds-sla-db
         id: sla-db
         brooklyn.config:
-          creationScriptUrl: https://raw.githubusercontent.com/SeaCloudsEU/SeaCloudsPlatform/60ae47c3cdf50412cf5541c4f089e59433823a53/sla/sla-core/sla-repository/src/main/resources/sql/01database.sql
-        install.latch: $brooklyn:component("monitor-manager").attributeWhenReady("service.isUp")
+          creationScriptUrl: https://raw.githubusercontent.com/SeaCloudsEU/sla-core/e1d3bd4dec27236cfdefa1eae81d38db3dcd11da/sla-repository/src/main/resources/sql/01database.sql
+        install.latch: $brooklyn:component("seaclouds-dc").attributeWhenReady("service.isUp")
       - type: seaclouds-monitor-manager
         name: seaclouds-monitor-manager
         brooklyn.config:
@@ -541,7 +563,7 @@ brooklyn.catalog:
       - type: seaclouds-data-collector
         id: seaclouds-dc
         name: seaclouds-dc
-        install.latch: $brooklyn:component("monitor-manager").attributeWhenReady("service.isUp")
+        launch.latch: $brooklyn:component("monitor-manager").attributeWhenReady("service.isUp")
       - type: seaclouds-discoverer
         name: seaclouds-discoverer
         id: discoverer
@@ -628,7 +650,6 @@ brooklyn.catalog:
       - type: seaclouds-data-collector
         id: seaclouds-dc
         name: seaclouds-dc
-        install.latch: $brooklyn:component("monitor-manager").attributeWhenReady("service.isUp")
       - type: seaclouds-discoverer
         name: seaclouds-discoverer
         id: discoverer

--- a/byon/files/seaclouds-catalog.bom
+++ b/byon/files/seaclouds-catalog.bom
@@ -419,7 +419,7 @@ brooklyn.catalog:
 
       brooklyn.config:
         runtimeFiles:
-          https://oss.sonatype.org/content/repositories/snapshots/eu/seaclouds-project/monitor/seaclouds-data-collector/1.1.0-SNAPSHOT/seaclouds-data-collector-1.1.0-20160421.085909-4.jar : seaclouds-dc.jar
+          https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project.monitor&a=seaclouds-data-collector&v=LATEST&e=jar : seaclouds-dc.jar
         http.port: 8176
 
       shell.env:


### PR DESCRIPTION
This PR adds the deployment of the seaclouds-dc in the catalog.bom in order to be deployed within the SeaClouds Platform. At the end of the deployment of the seaclouds-dc it is also installed a monitoring rule that need to be statically added to the Monitor Manager. @kiuby88 @rosogon can you have a look?