### PR TITLE
Adds penalties API and display of penalties in dashboard

### DIFF
--- a/dashboard/src/main/java/eu/seaclouds/platform/dashboard/proxy/SlaProxy.java
+++ b/dashboard/src/main/java/eu/seaclouds/platform/dashboard/proxy/SlaProxy.java
@@ -19,6 +19,7 @@ package eu.seaclouds.platform.dashboard.proxy;
 
 
 import eu.atos.sla.parser.data.GuaranteeTermsStatus;
+import eu.atos.sla.parser.data.Penalty;
 import eu.atos.sla.parser.data.Violation;
 import eu.atos.sla.parser.data.wsag.Agreement;
 import eu.atos.sla.parser.data.wsag.GuaranteeTerm;
@@ -153,6 +154,29 @@ public class SlaProxy extends AbstractProxy {
                 .buildGet().invoke().readEntity(String.class);
         try {
             return mapper.readValue(json, new TypeReference<List<Violation>>(){});
+        } catch (IOException e) {
+            /*
+             * TODO: Change Runtime for a DashboardException
+             */
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Creates proxied HTTP GET request to SeaClouds SLA core which retrieves the Agreement Term Penalties
+     * @param agreement which contains the guaranteeTerm to fetch
+     * @param guaranteeTerm to check penalties
+     * @return the list of Penalties for this <Agreement, GuaranteeTerm> pair
+     */
+    public List<Penalty> getGuaranteeTermPenalties(Agreement agreement, GuaranteeTerm guaranteeTerm) {
+        String path = String.format("/penalties?agreementId=%s&guaranteeTerm=%s", 
+                agreement.getAgreementId(), guaranteeTerm.getName());
+        String json = getJerseyClient().target(getEndpoint() + path).request()
+                .header("Accept", MediaType.APPLICATION_JSON)
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .buildGet().invoke().readEntity(String.class);
+        try {
+            return mapper.readValue(json, new TypeReference<List<Penalty>>(){});
         } catch (IOException e) {
             /*
              * TODO: Change Runtime for a DashboardException

--- a/dashboard/src/main/java/eu/seaclouds/platform/dashboard/rest/SlaResource.java
+++ b/dashboard/src/main/java/eu/seaclouds/platform/dashboard/rest/SlaResource.java
@@ -110,7 +110,43 @@ public class SlaResource implements Resource{
         }
     }
 
+    
+    @GET
+    @Timed
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("agreements/{seaCloudsId}/terms/{termName}/penalties")
+    @ApiOperation(value="Get SLA Agreement Term Penalties for a particular SeaClouds Application Id and Term Name")
+    public Response getPenalties(@PathParam("seaCloudsId") String seaCloudsId, @PathParam("termName") String termName) {
+        if (seaCloudsId == null || termName == null) {
+            LOG.error("Missing input parameters");
+            return Response.status(Response.Status.NOT_ACCEPTABLE).build();
+        } else {
+            SeaCloudsApplicationData seaCloudsApplicationData = dataStore.getSeaCloudsApplicationDataById(seaCloudsId);
 
+            if (seaCloudsApplicationData == null) {
+                LOG.error("Application " + seaCloudsId + " not found");
+                return Response.status(Response.Status.BAD_REQUEST).build();
+            }
+
+            if(seaCloudsApplicationData.getAgreementId() == null){
+                LOG.error("Application " + seaCloudsId + " doesn't contain any agreement");
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            Agreement agreement = sla.getAgreement(seaCloudsApplicationData.getAgreementId());
+            GuaranteeTerm term = null;
+            for (GuaranteeTerm termItem : agreement.getTerms().getAllTerms().getGuaranteeTerms()) {
+                if(termItem.getName().equalsIgnoreCase(termName)){
+                    term = termItem;
+                    break;
+                }
+            }
+
+            return Response.ok(sla.getGuaranteeTermPenalties(agreement, term)).build();
+        }
+    }
+
+    
     @GET
     @Timed
     @Produces(MediaType.APPLICATION_JSON)

--- a/dashboard/src/main/resources/webapp/app.js
+++ b/dashboard/src/main/resources/webapp/app.js
@@ -91,6 +91,9 @@ seacloudsDashboard.factory('SeaCloudsApi', function ($http) {
         getAgreementTermViolations: function (seaCloudsId, termName) {
             return $http.get("/api/sla/agreements/" + seaCloudsId + "/terms/" + termName + "/violations");
         },
+        getAgreementTermPenalties: function (seaCloudsId, termName) {
+            return $http.get("/api/sla/agreements/" + seaCloudsId + "/terms/" + termName + "/penalties");
+        },
         getAamFromDesigner: function (designerTopology) {
             return $http.post("/api/aamwriter/translate", designerTopology);
         },
@@ -108,4 +111,3 @@ seacloudsDashboard.controller('GlobalCtrl', function ($scope, Page, SeaCloudsApi
     $scope.Page = Page;
     $scope.SeaCloudsApi = SeaCloudsApi;
 });
-

--- a/dashboard/src/main/resources/webapp/applications/application/sla/sla.html
+++ b/dashboard/src/main/resources/webapp/applications/application/sla/sla.html
@@ -104,6 +104,30 @@
                                 </tr>
                                 </tbody>
                             </table>
+                            <strong>Penalties</strong>
+                            <table datatable="" dt-options="dtOptions" class="table table-striped compact"
+                                   cellspacing="0">
+                                <thead>
+                                <tr>
+                                    <th>
+                                        <small>Date</small>
+                                    </th>
+                                    <th>
+                                        <small>Value</small>
+                                    </th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr ng-repeat="penalty in getActiveTermPenalties()">
+                                    <td>
+                                        <small>{{penalty.datetime}}</small>
+                                    </td>
+                                    <td>
+                                        <small>{{penalty.definition}}</small>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>

--- a/dashboard/src/main/resources/webapp/applications/application/sla/sla.js
+++ b/dashboard/src/main/resources/webapp/applications/application/sla/sla.js
@@ -82,6 +82,7 @@ angular.module('seacloudsDashboard.applications.application.sla', ['datatables',
         var selectedTermIndex;
         var selectedTermName;
         var selectedTermViolations;
+        var selectedTermPenalties;
         var rawAgreementVisible;
 
         $scope.codemirror = { agreement:  "RAW Agreement visualizer is not ready yet."};
@@ -111,6 +112,13 @@ angular.module('seacloudsDashboard.applications.application.sla', ['datatables',
                     // Handle error
                 })
 
+            $scope.SeaCloudsApi.getAgreementTermPenalties($scope.seaCloudsApplicationId, name).
+                success(function (penalties) {
+                    selectedTermPenalties = penalties;
+                }).
+                error(function () {
+                    // Handle error
+                });
         }
 
         $scope.getActiveTermName = function () {
@@ -120,6 +128,11 @@ angular.module('seacloudsDashboard.applications.application.sla', ['datatables',
         $scope.getActiveTermViolations = function () {
             return selectedTermViolations;
         }
+
+        $scope.getActiveTermPenalties = function () {
+            return selectedTermPenalties;
+        }
+
         $scope.getSlaTermQoS = function () {
             if ($scope.agreement) {
                 var obj = JSON.parse($scope.agreement.terms.allTerms.guaranteeTerms[selectedTermIndex].serviceLevelObjetive.kpitarget.customServiceLevel);

--- a/dashboard/src/test/java/eu/seaclouds/platform/dashboard/rest/AbstractResourceTest.java
+++ b/dashboard/src/test/java/eu/seaclouds/platform/dashboard/rest/AbstractResourceTest.java
@@ -18,7 +18,9 @@
 package eu.seaclouds.platform.dashboard.rest;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
 import eu.atos.sla.parser.data.GuaranteeTermsStatus;
+import eu.atos.sla.parser.data.Penalty;
 import eu.atos.sla.parser.data.Violation;
 import eu.atos.sla.parser.data.wsag.Agreement;
 import eu.atos.sla.parser.data.wsag.GuaranteeTerm;
@@ -28,6 +30,7 @@ import eu.seaclouds.platform.dashboard.util.ObjectMapperHelpers;
 import eu.seaclouds.platform.dashboard.utils.TestFixtures;
 import eu.seaclouds.platform.dashboard.utils.TestUtils;
 import it.polimi.tower4clouds.rules.MonitoringRules;
+
 import org.apache.brooklyn.rest.domain.ApplicationSummary;
 import org.apache.brooklyn.rest.domain.EntitySummary;
 import org.apache.brooklyn.rest.domain.SensorSummary;
@@ -38,6 +41,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
 import javax.xml.bind.JAXBException;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -64,6 +68,7 @@ public abstract class AbstractResourceTest<T extends Resource> {
     private Agreement agreement;
     private GuaranteeTermsStatus agreementStatus;
     private List<Violation> agreementTermViolations;
+    private List<Penalty> agreementTermPenalties;
     private MonitoringRules monitoringRules;
     private String topology;
     private String adp;
@@ -96,7 +101,8 @@ public abstract class AbstractResourceTest<T extends Resource> {
         agreementStatus = ObjectMapperHelpers.JsonToObject(
                 TestUtils.getStringFromPath(TestFixtures.AGREEMENT_STATUS_PATH_JSON), GuaranteeTermsStatus.class);
         agreementTermViolations = ObjectMapperHelpers.JsonToObjectCollection(TestUtils.getStringFromPath(TestFixtures.VIOLATIONS_JSON_PATH), Violation.class);
-
+        agreementTermPenalties = ObjectMapperHelpers.JsonToObjectCollection(
+                TestUtils.getStringFromPath(TestFixtures.PENALTIES_JSON_PATH), Penalty.class);
         monitoringRules = ObjectMapperHelpers.XmlToObject(TestUtils.getStringFromPath(TestFixtures.MONITORING_RULES_PATH), MonitoringRules.class);
         topology = TestUtils.getStringFromPath(TestFixtures.DESIGNER_TOPOLOGY);
 
@@ -131,6 +137,7 @@ public abstract class AbstractResourceTest<T extends Resource> {
         when(slaProxy.getAgreementStatus(Matchers.<Agreement>any())).thenReturn(agreementStatus);
         when(slaProxy.getAgreementStatus(anyString())).thenReturn(agreementStatus);
         when(slaProxy.getGuaranteeTermViolations(Matchers.<Agreement>any(), Matchers.<GuaranteeTerm>any())).thenReturn(agreementTermViolations);
+        when(slaProxy.getGuaranteeTermPenalties(Matchers.<Agreement>any(), Matchers.<GuaranteeTerm>any())).thenReturn(agreementTermPenalties);
         when(slaProxy.notifyRulesReady(Matchers.<Agreement>any())).thenReturn(RANDOM_STRING);
         when(slaProxy.removeAgreement(anyString())).thenReturn(RANDOM_STRING);
     }

--- a/dashboard/src/test/java/eu/seaclouds/platform/dashboard/rest/SlaResourceTest.java
+++ b/dashboard/src/test/java/eu/seaclouds/platform/dashboard/rest/SlaResourceTest.java
@@ -18,11 +18,13 @@
 package eu.seaclouds.platform.dashboard.rest;
 
 import eu.atos.sla.parser.data.GuaranteeTermsStatus;
+import eu.atos.sla.parser.data.Penalty;
 import eu.atos.sla.parser.data.Violation;
 import eu.atos.sla.parser.data.wsag.Agreement;
 import eu.atos.sla.parser.data.wsag.GuaranteeTerm;
 import eu.seaclouds.platform.dashboard.model.SeaCloudsApplicationData;
 import eu.seaclouds.platform.dashboard.model.SeaCloudsApplicationDataStorage;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -66,5 +68,20 @@ public class SlaResourceTest extends AbstractResourceTest<SlaResource>{
         }
     }
 
+    @Test
+    public void testGetPenalties() throws Exception {
+        Agreement agreement = (Agreement) resource.getAgreement(applicationData.getSeaCloudsApplicationId())
+                .getEntity();
+
+        for(GuaranteeTerm term :  agreement.getTerms().getAllTerms().getGuaranteeTerms()){
+            List<Penalty> entity = (List<Penalty>) 
+                    resource.getPenalties(applicationData.getSeaCloudsApplicationId(), term.getName())
+                    .getEntity();
+            assertNotNull(entity);
+            for (Penalty p : entity) {
+                assertNotNull(p);
+            }
+        }
+    }
 
 }

--- a/dashboard/src/test/java/eu/seaclouds/platform/dashboard/utils/TestFixtures.java
+++ b/dashboard/src/test/java/eu/seaclouds/platform/dashboard/utils/TestFixtures.java
@@ -32,6 +32,7 @@ public interface TestFixtures {
     String AGREEMENT_PATH_JSON = "fixtures/agreement.json";
     String AGREEMENT_STATUS_PATH_JSON = "fixtures/agreement-status.json";
     String VIOLATIONS_JSON_PATH = "fixtures/violations.json";
+    String PENALTIES_JSON_PATH = "fixtures/penalties.json";
 
     // Monitor fixtures
     String MONITORING_RULES_PATH = "fixtures/monitoring-rules.xml";

--- a/dashboard/src/test/resources/fixtures/penalties.json
+++ b/dashboard/src/test/resources/fixtures/penalties.json
@@ -1,0 +1,35 @@
+[
+    {
+        "agreementId": "agreement01",
+        "datetime": "2016-05-01T20:45:57+0000",
+        "definition": {
+            "expression": "35",
+            "type": "discount",
+            "unit": "%",
+            "validity": "P1D"
+        },
+        "uuid": "5f555df5-c764-4d43-a065-be83d194769a"
+    },
+    {
+        "agreementId": "agreement01",
+        "datetime": "2016-05-01T20:45:54+0000",
+        "definition": {
+            "expression": "35",
+            "type": "discount",
+            "unit": "%",
+            "validity": "P1D"
+        },
+        "uuid": "0e03664d-3409-4c70-b159-8304d1d5121d"
+    },
+    {
+        "agreementId": "agreement01",
+        "datetime": "2016-05-01T20:44:41+0000",
+        "definition": {
+            "expression": "35",
+            "type": "discount",
+            "unit": "%",
+            "validity": "P1D"
+        },
+        "uuid": "277f0e11-5e49-419f-b111-5edb61e6d729"
+    }
+]


### PR DESCRIPTION
A new REST endpoint is added to retrieve the penalties associated to an
(agreement, term) pair.

The web application adds a new table in SLA tab that displays the
penalties for a term (under violations table).