### PR TITLE
Ensures sla-service is able to connect to db from localhost

### DIFF
--- a/sla/sla-core/sla-repository/src/main/resources/sql/01database.sql
+++ b/sla/sla-core/sla-repository/src/main/resources/sql/01database.sql
@@ -1,4 +1,4 @@
 -- Default database and user initialization
-CREATE DATABASE sc_sla;
-CREATE USER atossla@'%' IDENTIFIED BY '_atossla_';
-GRANT ALL PRIVILEGES ON sc_sla.* TO atossla@'%';
+CREATE DATABASE IF NOT EXISTS sc_sla;
+GRANT ALL PRIVILEGES ON sc_sla.* TO atossla@'%' IDENTIFIED BY '_atossla_';
+GRANT ALL PRIVILEGES ON sc_sla.* TO atossla@'localhost' IDENTIFIED BY '_atossla_';


### PR DESCRIPTION
Adds atossla user to connect from localhost.

From: https://dev.mysql.com/doc/refman/5.5/en/problems-connecting.html

If you cannot figure out why you get Access denied, remove from the user table all rows that have Host values containing wildcards (rows that contain '%' or '_' characters). A very common error is to insert a new row with Host='%' and User='some_user', thinking that this enables you to specify localhost to connect from the same machine. The reason that this does not work is that the default privileges include a row with Host='localhost' and User=''. Because that row has a Host value 'localhost' that is more specific than '%', it is used in preference to the new row when connecting from localhost! The correct procedure is to insert a second row with Host='localhost' and User='some_user', or to delete the row with Host='localhost' and User=''. After deleting the row, remember to issue a FLUSH PRIVILEGES statement to reload the grant tables. See also Section 6.2.4, “Access Control, Stage 1: Connection Verification”.